### PR TITLE
Make scheduler skip matching events by default

### DIFF
--- a/e2e/test_populate.py
+++ b/e2e/test_populate.py
@@ -122,3 +122,50 @@ def test_api_v0_populate_invalid(user, team, roster, role, schedule):
     assert re.status_code == 200
     re = requests.get(api_v0('schedules/%s' % schedule_id))
     assert re.json() == schedule_json
+
+
+# Test skipping over matching events
+@prefix('test_v0_populate_skip')
+def test_api_v0_populate_skip(user, team, roster, role, schedule, event):
+    user_name = user.create()
+    user_name_2 = user.create()
+    team_name = team.create()
+    role_name = role.create()
+    roster_name = roster.create(team_name)
+    schedule_id = schedule.create(team_name,
+                                  roster_name,
+                                  {'role': role_name,
+                                   'events': [{'start': 0, 'duration': 604800}],
+                                   'advanced_mode': 0,
+                                   'auto_populate_threshold': 14})
+    user.add_to_roster(user_name, team_name, roster_name)
+    user.add_to_roster(user_name_2, team_name, roster_name)
+
+
+    re = requests.post(api_v0('schedules/%s/populate' % schedule_id), json = {'start': time.time()})
+    assert re.status_code == 200
+
+    re = requests.get(api_v0('events?team=%s' % team_name))
+    assert re.status_code == 200
+    events = re.json()
+    assert len(events) == 2
+
+    event.create({
+        'start': events[0]['start'],
+        'end': events[0]['end'],
+        'user': user_name,
+        'team': team_name,
+        'role': role_name,
+    })
+
+    re = requests.post(api_v0('schedules/%s/populate' % schedule_id), json = {'start': time.time()})
+    assert re.status_code == 200
+
+    re = requests.get(api_v0('events?team=%s' % team_name))
+    assert re.status_code == 200
+    events = re.json()
+    assert len(events) == 2
+
+    schedule_ids = set([ev['schedule_id'] for ev in events])
+    assert None in schedule_ids
+    assert schedule_id in schedule_ids


### PR DESCRIPTION
Adds a bit of magic into the scheduler. We've received a lot of complaints that the scheduler should be able to detect manually created events on the calendar and skip that week. Here, we skip populating a week's events if there already exist events with the same role, team, start, and end.