### PR TITLE
Removed required LDAP attribute for image_url

### DIFF
--- a/src/oncall/user_sync/ldap_sync.py
+++ b/src/oncall/user_sync/ldap_sync.py
@@ -204,7 +204,7 @@ def sync(config, engine):
         logger.debug('Inserting %s' % username)
         full_name = ldap_users[username].pop('name')
         try:
-            user_id = engine.execute(user_add_sql, (username, full_name, LDAP_SETTINGS['image_url'] % username)).lastrowid
+            user_id = engine.execute(user_add_sql, (username, full_name)).lastrowid
         except SQLAlchemyError:
             stats['users_failed_to_add'] += 1
             stats['sql_errors'] += 1
@@ -234,7 +234,7 @@ def sync(config, engine):
                 engine.execute(name_update_sql, (full_name, username))
                 stats['user_names_updated'] += 1
             if not db_contacts.get('photo_url'):
-                engine.execute(photo_update_sql, (LDAP_SETTINGS['image_url'] % username, username))
+                engine.execute(photo_update_sql, (username))
                 stats['user_photos_updated'] += 1
             for mode in modes:
                 if mode in ldap_contacts and ldap_contacts[mode]:


### PR DESCRIPTION
* Please reference #80 on the main project page - https://github.com/linkedin/oncall/issues/80 for some additional conversation on this PR.

The ldap_sync.py script is expecting an LDAP attribute "image_url" to exist for each object polled. If the attribute doesn't exist the script fails and won't sync user account data.

I recommend to remove "image_url" as a requirement as not everyone will have this attribute in their own LDAP/AD environments.
The result of removing "image_url" is that the value will simply remain blank in the OnCall database (an acceptable result in my opinion).