### PR TITLE
Fixes Issue #89 - ldap_sync.py Breaks when 0 Users Currently Exist

### DIFF
--- a/src/oncall/user_sync/ldap_sync.py
+++ b/src/oncall/user_sync/ldap_sync.py
@@ -186,8 +186,12 @@ def sync(config, engine):
     # set of users in oncall but not ldap, assumed to be inactive
     inactive_users = oncall_usernames - ldap_usernames
     # users who need to be deactivated
-    rows = engine.execute('SELECT name FROM user WHERE active = TRUE AND name IN %s', inactive_users)
-    users_to_purge = (user.name for user in rows)
+    if inactive_users:
+        rows = engine.execute('SELECT name FROM user WHERE active = TRUE AND name IN %s', inactive_users)
+        users_to_purge = (user.name for user in rows)
+    else:
+        users_to_purge = []
+
 
     # set of inactive oncall users who appear in ldap
     rows = engine.execute('SELECT name FROM user WHERE active = FALSE AND name IN %s', ldap_usernames)


### PR DESCRIPTION
As discussed in https://github.com/linkedin/oncall/issues/89, this should be a quick fix for issues when the set of ldap_users and set of oncall_users are identical and yield an empty set.