### PR TITLE
Add team subscriptions

### DIFF
--- a/db/schema.v0.sql
+++ b/db/schema.v0.sql
@@ -417,6 +417,19 @@ CREATE TABLE IF NOT EXISTS `application` (
   PRIMARY KEY (`id`)
 );
 
+CREATE TABLE IF NOT EXISTS `team_subscription` (
+  `team_id`         BIGINT(20) UNSIGNED NOT NULL,
+  `subscription_id` BIGINT(20) UNSIGNED NOT NULL,
+  `role_id`         INT        UNSIGNED NOT NULL,
+  PRIMARY KEY (`team_id`, `subscription_id`, `role_id`),
+  INDEX `team_subscription_team_id_idx` (`team_id` ASC),
+  CONSTRAINT `team_subscription_team_id_fk` FOREIGN KEY (`team_id`) REFERENCES `team` (`id`)
+    ON DELETE CASCADE,
+  CONSTRAINT `team_subscription_subscription_id_fk` FOREIGN KEY (`subscription_id`) REFERENCES `team` (`id`)
+    ON DELETE CASCADE,
+  INDEX `team_subscription_team_id_fk_idx` (`team_id` ASC)
+);
+
 INSERT INTO `scheduler` ( `name`, `description`)
 VALUES ('default',
         'Default scheduling algorithm'),

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -179,7 +179,7 @@ def event(team, role):
             for ev in self.created:
                 requests.delete(api_v0('events/%d' % ev))
             for t in self.teams:
-                re = requests.get(api_v0('events?team=' + t))
+                re = requests.get(api_v0('events?include_subscribed=false'), params={'team': t})
                 for ev in re.json():
                     requests.delete(api_v0('events/%d' % ev['id']))
 

--- a/e2e/test_events.py
+++ b/e2e/test_events.py
@@ -14,7 +14,7 @@ def test_invalid_events():
 
 
 @prefix('test_events')
-def test_events(team, user, role):
+def test_events(event, team, user, role):
     team_name = team.create()
     team_name_2 = team.create()
     user_name = user.create()
@@ -24,6 +24,8 @@ def test_events(team, user, role):
     user.add_to_team(user_name, team_name)
     user.add_to_team(user_name_2, team_name)
     user.add_to_team(user_name_2, team_name_2)
+    event.teams.add(team_name)
+    event.teams.add(team_name_2)
 
     start, end = int(time.time()) + 100, int(time.time() + 36000)
 

--- a/e2e/test_subscription.py
+++ b/e2e/test_subscription.py
@@ -1,0 +1,161 @@
+import time
+import requests
+from testutils import prefix, api_v0
+
+
+@prefix('test_v0_sub')
+def test_api_v0_team_subscription(team, role):
+    team_name = team.create()
+    team_name_2 = team.create()
+    team_name_3 = team.create()
+    role_name = role.create()
+
+    re = requests.post(api_v0('teams/%s/subscriptions' % team_name), json={'role': role_name, 'subscription': team_name_2})
+    assert re.status_code == 201
+    re = requests.post(api_v0('teams/%s/subscriptions' % team_name), json={'role': role_name, 'subscription': team_name_3})
+    assert re.status_code == 201
+
+    re = requests.get(api_v0('teams/%s/subscriptions' % team_name))
+    assert re.status_code == 200
+    data = re.json()
+    assert team_name_2 in data
+    assert team_name_3 in data
+    assert len(data) == 2
+
+    re = requests.delete(api_v0('teams/%s/subscriptions/%s/%s' % (team_name, team_name_3, role_name)))
+    assert re.status_code == 200
+
+    re = requests.get(api_v0('teams/%s/subscriptions' % team_name))
+    assert re.status_code == 200
+    data = re.json()
+    assert team_name_2 in data
+    assert len(data) == 1
+
+
+@prefix('test_v0_sub_events')
+def test_api_v0_subscription_events(user, role, team, event):
+    team_name = team.create()
+    team_name_2 = team.create()
+    user_name = user.create()
+    role_name = role.create()
+    user.add_to_team(user_name, team_name)
+    user.add_to_team(user_name, team_name_2)
+    start = int(time.time()) + 1000
+    ev1 = event.create({'start': start,
+                        'end': start + 1000,
+                        'user': user_name,
+                        'team': team_name,
+                        'role': role_name})
+    ev2 = event.create({'start': start + 1000,
+                        'end': start + 2000,
+                        'user': user_name,
+                        'team': team_name_2,
+                        'role': role_name})
+    re = requests.post(api_v0('teams/%s/subscriptions' % team_name), json={'role': role_name, 'subscription': team_name_2})
+    assert re.status_code == 201
+    re = requests.get(api_v0('events?team__eq=%s' % team_name))
+    ev_ids = [ev['id'] for ev in re.json()]
+    assert ev1 in ev_ids
+    assert ev2 in ev_ids
+
+    re = requests.get(api_v0('events?team__eq=%s&include_subscribed=False' % team_name))
+    ev_ids = [ev['id'] for ev in re.json()]
+    assert ev1 in ev_ids
+    assert len(ev_ids) == 1
+
+
+@prefix('test_v0_sub_oncall')
+def test_v0_subscription_oncall(user, role, team, service, event):
+    team_name = team.create()
+    team_name_2 = team.create()
+    service_name = service.create()
+    service.associate_team(service_name, team_name)
+    user_name = user.create()
+    user_name_2 = user.create()
+    role_name = role.create()
+    user.add_to_team(user_name, team_name)
+    user.add_to_team(user_name_2, team_name_2)
+    re = requests.post(api_v0('teams/%s/subscriptions' % team_name), json={'role': role_name, 'subscription': team_name_2})
+    assert re.status_code == 201
+    start = int(time.time())
+
+    ev1 = event.create({'start': start,
+                        'end': start + 1000,
+                        'user': user_name,
+                        'team': team_name,
+                        'role': role_name})
+    ev2 = event.create({'start': start,
+                        'end': start + 1000,
+                        'user': user_name_2,
+                        'team': team_name_2,
+                        'role': role_name})
+
+    re = requests.get(api_v0('services/%s/oncall/%s' % (service_name, role_name)))
+    assert re.status_code == 200
+    results = re.json()
+    users = [ev['user'] for ev in results]
+    assert user_name in users
+    assert user_name_2 in users
+    assert len(results) == 2
+
+
+@prefix('test_v0_sub_summary')
+def test_v0_subscription_summary(user, role, team, event):
+    team_name = team.create()
+    team_name_2 = team.create()
+    user_name = user.create()
+    user_name_2 = user.create()
+    role_name = role.create()
+    role_name_2 = role.create()
+    user.add_to_team(user_name, team_name)
+    user.add_to_team(user_name_2, team_name_2)
+
+    start, end = int(time.time()), int(time.time()+36000)
+
+    event_data_1 = {'start': start,
+                    'end': end,
+                    'user': user_name,
+                    'team': team_name,
+                    'role': role_name}
+    event_data_2 = {'start': start - 5,
+                    'end': end - 5,
+                    'user': user_name_2,
+                    'team': team_name_2,
+                    'role': role_name_2}
+    event_data_3 = {'start': start + 50000,
+                    'end': end + 50000,
+                    'user': user_name,
+                    'team': team_name,
+                    'role': role_name}
+    event_data_4 = {'start': start + 50005,
+                    'end': end + 50005,
+                    'user': user_name_2,
+                    'team': team_name_2,
+                    'role': role_name_2}
+    event_data_5 = {'start': start + 50001,
+                    'end': end + 50001,
+                    'user': user_name,
+                    'team': team_name,
+                    'role': role_name}
+
+    # Create current events
+    event.create(event_data_1)
+    event.create(event_data_2)
+    # Create next events
+    event.create(event_data_3)
+    event.create(event_data_4)
+    # Create extra future event that isn't the next event
+    event.create(event_data_5)
+
+    re = requests.post(api_v0('teams/%s/subscriptions' % team_name), json={'role': role_name_2, 'subscription': team_name_2})
+    assert re.status_code == 201
+
+    re = requests.get(api_v0('teams/%s/summary' % team_name))
+    assert re.status_code == 200
+    results = re.json()
+    keys = ['start', 'end', 'role']
+
+    assert all(results['current'][role_name][0][key] == event_data_1[key] for key in keys)
+    assert all(results['current'][role_name_2][0][key] == event_data_2[key] for key in keys)
+    assert all(results['next'][role_name][0][key] == event_data_3[key] for key in keys)
+    assert all(results['next'][role_name_2][0][key] == event_data_4[key] for key in keys)

--- a/src/oncall/api/v0/__init__.py
+++ b/src/oncall/api/v0/__init__.py
@@ -82,6 +82,10 @@ def init(application, config):
     from . import timezones
     application.add_route('/api/v0/timezones', timezones)
 
+    from . import team_subscription, team_subscriptions
+    application.add_route('/api/v0/teams/{team}/subscriptions', team_subscriptions)
+    application.add_route('/api/v0/teams/{team}/subscriptions/{subscription}/{role}', team_subscription)
+
     # Optional Iris integration
     from . import iris_settings
     application.add_route('/api/v0/iris_settings', iris_settings)

--- a/src/oncall/api/v0/team_subscription.py
+++ b/src/oncall/api/v0/team_subscription.py
@@ -1,0 +1,22 @@
+from ... import db
+from ...auth import login_required, check_team_auth
+from falcon import HTTPNotFound
+
+
+@login_required
+def on_delete(req, resp, team, subscription, role):
+    check_team_auth(team, req)
+    connection = db.connect()
+    cursor = connection.cursor()
+
+    cursor.execute('''DELETE FROM `team_subscription`
+                      WHERE team_id = (SELECT `id` FROM `team` WHERE `name` = %s)
+                      AND `subscription_id` = (SELECT `id` FROM `team` WHERE `name` = %s)\
+                      AND `role_id` = (SELECT `id` FROM `role` WHERE `name` = %s)''',
+                   (team, subscription, role))
+    deleted = cursor.rowcount
+    connection.commit()
+    cursor.close()
+    connection.close()
+    if deleted == 0:
+        raise HTTPNotFound()

--- a/src/oncall/api/v0/team_subscriptions.py
+++ b/src/oncall/api/v0/team_subscriptions.py
@@ -1,0 +1,58 @@
+from ... import db
+from ujson import dumps as json_dumps
+from falcon import HTTPError, HTTPBadRequest, HTTP_201
+from ...utils import load_json_body
+from ...auth import login_required, check_team_auth
+import logging
+
+logger = logging.getLogger('oncall-api')
+
+
+def on_get(req, resp, team):
+    connection = db.connect()
+    cursor = connection.cursor()
+    cursor.execute('''SELECT `subscription`.`name`, `role`.`name` FROM `team`
+                      JOIN `team_subscription` ON `team`.`id` = `team_subscription`.`team_id`
+                      JOIN `team` `subscription` ON `subscription`.`id` = `team_subscription`.`subscription_id`
+                      JOIN `role` ON `role`.`id` = `team_subscription`.`role_id`
+                      WHERE `team`.`name` = %s''',
+                   team)
+    data = [row[0] for row in cursor]
+    cursor.close()
+    connection.close()
+    resp.body = json_dumps(data)
+
+
+@login_required
+def on_post(req, resp, team):
+    data = load_json_body(req)
+    check_team_auth(team, req)
+    sub_name = data.get('subscription')
+    role_name = data.get('role')
+    if not sub_name or not role_name:
+        raise HTTPBadRequest('Invalid subscription', 'Missing subscription name or role name')
+    connection = db.connect()
+    cursor = connection.cursor()
+    try:
+        cursor.execute('''INSERT INTO `team_subscription` (`team_id`, `subscription_id`, `role_id`) VALUES
+                          ((SELECT `id` FROM `team` WHERE `name` = %s),
+                           (SELECT `id` FROM `team` WHERE `name` = %s),
+                           (SELECT `id` FROM `role` WHERE `name` = %s))''',
+                       (team, sub_name, role_name))
+    except db.IntegrityError as e:
+        err_msg = str(e.args[1])
+        if err_msg == 'Column \'team_id\' cannot be null':
+            err_msg = 'team "%s" not found' % team
+        elif err_msg == 'Column \'role_id\' cannot be null':
+            err_msg = 'role "%s" not found' % role_name
+        elif err_msg == 'Column \'subscription_id\' cannot be null':
+            err_msg = 'team "%s" not found' % sub_name
+        logger.exception('Unknown integrity error in team_subscriptions')
+        raise HTTPError('422 Unprocessable Entity', 'IntegrityError', err_msg)
+    else:
+        connection.commit()
+    finally:
+        cursor.close()
+        connection.close()
+
+    resp.status = HTTP_201


### PR DESCRIPTION
Add backend to allow a team to "subscribe" to another team, filtered by role. For example, team A could subscribe to team B's manager events, having team B's manager events appear on the team A calendar. This keeps scheduling in one place.