### PR TITLE
Use the configured ldap_sync[attrs][username] value

### DIFF
--- a/src/oncall/user_sync/ldap_sync.py
+++ b/src/oncall/user_sync/ldap_sync.py
@@ -117,7 +117,12 @@ def fetch_ldap():
                 logger.error('ERROR: invalid ldap entry for dn: %s' % dn)
                 continue
 
-            username = ldap_dict['sAMAccountName'][0]
+            try:
+                username_field = LDAP_SETTINGS['attrs']['username']
+            except KeyError:
+                username_field = "sAMAccountName"
+
+            username = ldap_dict[username_field][0]
 
             mobile = ldap_dict.get(LDAP_SETTINGS['attrs']['mobile'])
             mail = ldap_dict.get(LDAP_SETTINGS['attrs']['mail'])


### PR DESCRIPTION
Solves this exception against non-AD ldap:

```
Traceback (most recent call last):
  File "/home/oncall/env/local/lib/python2.7/site-packages/gevent/greenlet.py", line 536, in run
    result = self._run(*self.args, **self.kwargs)
  File "/home/oncall/env/local/lib/python2.7/site-packages/oncall/user_sync/ldap_sync.py", line 306, in main
    sync(config, engine)
  File "/home/oncall/env/local/lib/python2.7/site-packages/oncall/user_sync/ldap_sync.py", line 180, in sync
    ldap_users = fetch_ldap()
  File "/home/oncall/env/local/lib/python2.7/site-packages/oncall/user_sync/ldap_sync.py", line 123, in fetch_ldap
    username = ldap_dict['sAMAccountName'][0]
KeyError: 'sAMAccountName'
```

Retains old behavior with regard to sAMAccountName being the default.