### PR TITLE
Update packer documentation

### DIFF
--- a/ops/packer/README.md
+++ b/ops/packer/README.md
@@ -1,3 +1,6 @@
+```mkdir output```
+```python gen_packer_cfg.py ./oncall.yaml | tail -n +2 > ./output/oncall.json```
+```packer build -only=docker oncall.json```
 ```docker run --name oncall-mysql -e MYSQL_ROOT_PASSWORD='1234' -d mysql```
 ```docker run -d --link oncall-mysql:mysql -p 8080:8080 -e DOCKER_DB_BOOTSTRAP=1 quay.io/iris/oncall```
 


### PR DESCRIPTION
There seems to be zero documentation on gen_packer_cfg.py.
The tail is there is to remove the 1st line of output from gen_packer_cfg.py, which is informative and obviously not valid json.