### PR TITLE
Allow http login without resorting to debug mode

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -39,6 +39,9 @@ messengers:
     application: oncall
     iris_api_key: magic
 
+## To run Oncall without https, set this value to True
+#allow_http: False
+
 # allow_origins_list:
 #   - http://www.example.com
 

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -40,6 +40,8 @@ messengers:
     iris_api_key: magic
 
 ## To run Oncall without https, set this value to True
+## WARNING: use this only for debugging purposes, to avoid sending
+## usernames and passwords in plain text.
 #allow_http: False
 
 # allow_origins_list:

--- a/src/oncall/app.py
+++ b/src/oncall/app.py
@@ -130,7 +130,7 @@ def init(config):
         'session.key': 'oncall-auth',
         'session.encrypt_key': config['session']['encrypt_key'],
         'session.validate_key': config['session']['sign_key'],
-        'session.secure': not config.get('debug', False),
+        'session.secure': not (config.get('debug', False) or config.get('allow_http', False)),
         'session.httponly': True
     }
     application = SessionMiddleware(application, session_opts)


### PR DESCRIPTION
Currently when setting debug: False, it's not possible to properly login, as the session cookie isn't being set.

For various reasons it's convenient to be able to run a fully functional Oncall without having to set up https.