### PR TITLE
Edit user settings

### DIFF
--- a/db/schema.v0.sql
+++ b/db/schema.v0.sql
@@ -289,12 +289,13 @@ CREATE TABLE IF NOT EXISTS `roster_user` (
 CREATE TABLE IF NOT EXISTS `contact_mode` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
+  `label` varchar(255) NOT NULL,
   PRIMARY KEY (`id`)
 );
 -- -----------------------------------------------------
 -- Initialize contact modes
 -- -----------------------------------------------------
-INSERT INTO `contact_mode` (`name`)
+INSERT INTO `contact_mode` (`name`, `label`)
 VALUES ('email'), ('sms'), ('call'), ('slack');
 
 -- -----------------------------------------------------

--- a/src/oncall/api/v0/modes.py
+++ b/src/oncall/api/v0/modes.py
@@ -7,9 +7,9 @@ def on_get(req, resp):
     Get all contact modes
     """
     connection = db.connect()
-    cursor = connection.cursor()
-    cursor.execute('SELECT `name` FROM `contact_mode`')
-    data = [row[0] for row in cursor]
+    cursor = connection.cursor(db.DictCursor)
+    cursor.execute('SELECT `name`, `label` FROM `contact_mode`')
+    data = cursor.fetchall()
     cursor.close()
     connection.close()
     resp.body = json_dumps(data)

--- a/src/oncall/api/v0/user.py
+++ b/src/oncall/api/v0/user.py
@@ -122,7 +122,7 @@ def on_put(req, resp, user_name):
     :statuscode 204: Successful edit
     :statuscode 404: User not found
     """
-    contacts_query = '''INSERT INTO user_contact (`user_id`, `mode_id`, `destination`) VALUES
+    contacts_query = '''REPLACE INTO user_contact (`user_id`, `mode_id`, `destination`) VALUES
                            ((SELECT `id` FROM `user` WHERE `name` = %(user)s),
                             (SELECT `id` FROM `contact_mode` WHERE `name` = %(mode)s),
                             %(destination)s)

--- a/src/oncall/api/v0/user.py
+++ b/src/oncall/api/v0/user.py
@@ -143,7 +143,10 @@ def on_put(req, resp, user_name):
     cursor = connection.cursor()
     if set_clause:
         query = 'UPDATE `user` SET {0} WHERE `name` = %s'.format(set_clause)
-        query_data = tuple(data[field] for field in data) + (user_name,)
+        query_data = ()
+        for field in data:
+            if field != 'contacts':
+                query_data += (data[field], user_name)
 
         cursor.execute(query, query_data)
         if cursor.rowcount != 1:

--- a/src/oncall/ui/__init__.py
+++ b/src/oncall/ui/__init__.py
@@ -63,7 +63,7 @@ INDEX_CONTENT_SETTING = {
 SLACK_INSTANCE = None
 HEADER_COLOR = None
 IRIS_PLAN_SETTINGS = None
-USERCONTACT_UI_STATE = "readonly"
+USERCONTACT_UI_READONLY = None
 
 
 def index(req, resp):
@@ -76,7 +76,7 @@ def index(req, resp):
         missing_number_note=INDEX_CONTENT_SETTING['missing_number_note'],
         header_color=HEADER_COLOR,
         iris_plan_settings=IRIS_PLAN_SETTINGS,
-        usercontact_ui_state=USERCONTACT_UI_STATE,
+        usercontact_ui_readonly=USERCONTACT_UI_READONLY,
         footer=INDEX_CONTENT_SETTING['footer'],
         timezones=SUPPORTED_TIMEZONES
     )
@@ -120,14 +120,11 @@ def init(application, config):
     global SLACK_INSTANCE
     global HEADER_COLOR
     global IRIS_PLAN_SETTINGS
-    global USERCONTACT_UI_STATE
+    global USERCONTACT_UI_READONLY
     SLACK_INSTANCE = config.get('slack_instance')
     HEADER_COLOR = config.get('header_color', '#3a3a3a')
     IRIS_PLAN_SETTINGS = config.get('iris_plan_integration')
-    usercontact_ui_readonly = config.get('usercontact_ui_readonly', True)
-    USERCONTACT_UI_STATE = ''
-    if usercontact_ui_readonly:
-        USERCONTACT_UI_STATE = 'readonly'
+    USERCONTACT_UI_READONLY = config.get('usercontact_ui_readonly', False)
 
     application.add_sink(index, '/')
     application.add_route('/static/bundles/{filename}',

--- a/src/oncall/ui/__init__.py
+++ b/src/oncall/ui/__init__.py
@@ -63,6 +63,7 @@ INDEX_CONTENT_SETTING = {
 SLACK_INSTANCE = None
 HEADER_COLOR = None
 IRIS_PLAN_SETTINGS = None
+USERCONTACT_UI_STATE = "readonly"
 
 
 def index(req, resp):
@@ -75,6 +76,7 @@ def index(req, resp):
         missing_number_note=INDEX_CONTENT_SETTING['missing_number_note'],
         header_color=HEADER_COLOR,
         iris_plan_settings=IRIS_PLAN_SETTINGS,
+        usercontact_ui_state=USERCONTACT_UI_STATE,
         footer=INDEX_CONTENT_SETTING['footer'],
         timezones=SUPPORTED_TIMEZONES
     )
@@ -118,9 +120,14 @@ def init(application, config):
     global SLACK_INSTANCE
     global HEADER_COLOR
     global IRIS_PLAN_SETTINGS
+    global USERCONTACT_UI_STATE
     SLACK_INSTANCE = config.get('slack_instance')
     HEADER_COLOR = config.get('header_color', '#3a3a3a')
     IRIS_PLAN_SETTINGS = config.get('iris_plan_integration')
+    usercontact_ui_readonly = config.get('usercontact_ui_readonly', True)
+    USERCONTACT_UI_STATE = ''
+    if usercontact_ui_readonly:
+        USERCONTACT_UI_STATE = 'readonly'
 
     application.add_sink(index, '/')
     application.add_route('/static/bundles/{filename}',

--- a/src/oncall/ui/static/js/oncall.js
+++ b/src/oncall/ui/static/js/oncall.js
@@ -2068,23 +2068,14 @@ var oncall = {
         url: url,
         dataType: 'html',
         contentType: 'application/json',
-        data: JSON.stringify({time_zone: data})
+        data: JSON.stringify({contacts: userContacts, time_zone: data})
       }).done(function(){
         oncall.data.userTimezone = data;
         oncall.alerts.createAlert('Settings saved.', 'success', $form);
       }).fail(function(data){
-        var error = oncall.isJson(data.responseText) ? JSON.parse(data.responseText).description : data.responseText || 'Update timezone failed.';
+        var error = oncall.isJson(data.responseText) ? JSON.parse(data.responseText).description : data.responseText || 'Update failed.';
         oncall.alerts.createAlert(error, 'danger');
-      }).then($.ajax({
-        type: 'PUT',
-        url: url,
-        dataType: 'html',
-        contentType: 'application/json',
-        data: JSON.stringify({contacts: userContacts})
-      }).fail(function(data){
-        var error = oncall.isJson(data.responseText) ? JSON.parse(data.responseText).description : data.responseText || 'Update contacts failed.';
-        oncall.alerts.createAlert(error, 'danger');
-      })).always(function(){
+      }).always(function(){
         $cta.removeClass('loading disabled').prop('disabled', false);
       });
 

--- a/src/oncall/ui/static/js/oncall.js
+++ b/src/oncall/ui/static/js/oncall.js
@@ -2007,6 +2007,7 @@ var oncall = {
     },
     init: function(){
       Handlebars.registerPartial('settings-subheader', this.data.settingsSubheaderTemplate);
+      oncall.getModes();
       this.getData();
     },
     events: function(){
@@ -2021,6 +2022,22 @@ var oncall = {
       }
     },
     renderPage: function(data){
+      $.when(
+        oncall.data.modesPromise
+      ).done(function() {
+        let contactModes = [];
+
+        for(let key in data.contacts)
+        {
+          let currentMode = oncall.data.modes.find(x => x.name === key);
+          contactModes.push({
+            key: currentMode.label,
+            value: data.contacts[key]
+          });
+        }
+        data.contactmodes = contactModes;
+        data.telmodes = ["Phone", "SMS Number"];
+      });
       var template = Handlebars.compile(this.data.pageSource),
            self = this;
       oncall.data.timezonesPromise.done(function() {

--- a/src/oncall/ui/templates/index.html
+++ b/src/oncall/ui/templates/index.html
@@ -1166,14 +1166,14 @@
             <span>
             {{#inArray mode ../telmodes}}
               {{#if value}}
-                <input type="text" name="contactmode-{{mode}}" id="{{mode}}" class="form-control" value="{{value}}" />
+                <input type="text" name="contactmode-{{mode}}" id="{{mode}}" class="form-control" value="{{value}}" {% endraw %} {{ usercontact_ui_state }} {% raw %} />
                 <!-- <a href="tel:{{value}}"> {{value}} </a> -->
               {{else}}
-                <input type="text" name="contactmode-{{mode}}" id="{{mode}}" class="form-control" placeholder="{% endraw %}{{missing_number_note|safe}}{% raw %}" />
+                <input type="text" name="contactmode-{{mode}}" id="{{mode}}" class="form-control" placeholder="{% endraw %}{{missing_number_note|safe}} {{ usercontact_ui_state }} {% raw %} " />
               {{/if}}
             {{/inArray}}
             {{^inArray mode ../telmodes}}
-              <input type="text" name="contactmode-{{mode}}" id="{{mode}}" class="form-control" value="{{value}}" />
+              <input type="text" name="contactmode-{{mode}}" id="{{mode}}" class="form-control" value="{{value}}" {% endraw %} {{ usercontact_ui_state }} {% raw %} />
             {{/inArray}}
             </span>
           </td>

--- a/src/oncall/ui/templates/index.html
+++ b/src/oncall/ui/templates/index.html
@@ -1161,20 +1161,19 @@
         </tr>
         {{#each contactmodes}}
         <tr>
-          <td>{{key}}</td>
+          <td>{{label}}</td>
           <td>
             <span>
-            {{#inArray key ../telmodes}}
+            {{#inArray mode ../telmodes}}
               {{#if value}}
-                <a href="tel:{{value}}"> {{value}} </a>
+                <input type="text" name="contactmode-{{mode}}" id="{{mode}}" class="form-control" value="{{value}}" />
+                <!-- <a href="tel:{{value}}"> {{value}} </a> -->
               {{else}}
-                {% endraw %}
-                  {{missing_number_note|safe}}
-                {% raw %}
+                <input type="text" name="contactmode-{{mode}}" id="{{mode}}" class="form-control" placeholder="{% endraw %}{{missing_number_note|safe}}{% raw %}" />
               {{/if}}
             {{/inArray}}
-            {{^inArray key ../telmodes}}
-              {{value}}
+            {{^inArray mode ../telmodes}}
+              <input type="text" name="contactmode-{{mode}}" id="{{mode}}" class="form-control" value="{{value}}" />
             {{/inArray}}
             </span>
           </td>

--- a/src/oncall/ui/templates/index.html
+++ b/src/oncall/ui/templates/index.html
@@ -1164,17 +1164,22 @@
           <td>{{label}}</td>
           <td>
             <span>
-            {{#inArray mode ../telmodes}}
-              {{#if value}}
-                <input type="text" name="contactmode-{{mode}}" id="{{mode}}" class="form-control" value="{{value}}" {% endraw %} {{ usercontact_ui_state }} {% raw %} />
-                <!-- <a href="tel:{{value}}"> {{value}} </a> -->
-              {{else}}
-                <input type="text" name="contactmode-{{mode}}" id="{{mode}}" class="form-control" placeholder="{% endraw %}{{missing_number_note|safe}} {{ usercontact_ui_state }} {% raw %} " />
-              {{/if}}
-            {{/inArray}}
-            {{^inArray mode ../telmodes}}
-              <input type="text" name="contactmode-{{mode}}" id="{{mode}}" class="form-control" value="{{value}}" {% endraw %} {{ usercontact_ui_state }} {% raw %} />
-            {{/inArray}}
+            {% endraw %} {% if usercontact_ui_readonly %} {% raw %}
+              {{#inArray mode ../telmodes}}
+                  {{#if value}}
+                    <a href="tel:{{value}}"> {{value}} </a>
+                  {{else}}
+                    {% endraw %}
+                      {{missing_number_note|safe}}
+                    {% raw %}
+                  {{/if}}
+              {{/inArray}}
+              {{^inArray mode ../telmodes}}
+                <span>{{value}}</span>
+              {{/inArray}}
+            {% endraw %} {% else %} {% raw %}
+                <input type="text" name="contactmode-{{mode}}" id="{{mode}}" class="form-control" value="{{value}}" />
+            {% endraw %} {% endif %} {% raw %}
             </span>
           </td>
         </tr>

--- a/src/oncall/ui/templates/index.html
+++ b/src/oncall/ui/templates/index.html
@@ -1159,46 +1159,27 @@
             </select>
           </td>
         </tr>
+        {{#each contactmodes}}
         <tr>
-          <td>Phone</td>
+          <td>{{key}}</td>
           <td>
             <span>
-            {{#if contacts.call}}
-              <a href="tel:{{contacts.call}}"> {{contacts.call}} </a>
-            {{else}}
-              {% endraw %}
-                {{missing_number_note|safe}}
-              {% raw %}
-            {{/if}}
-            </span>
-          </td>
-        </tr>
-        <tr>
-          <td>SMS Number</td>
-          <td>
-            <span>
-              {{#if contacts.sms}}
-                <a href="tel:{{contacts.sms}}"> {{contacts.sms}} </a>
+            {{#inArray key ../telmodes}}
+              {{#if value}}
+                <a href="tel:{{value}}"> {{value}} </a>
               {{else}}
                 {% endraw %}
                   {{missing_number_note|safe}}
                 {% raw %}
               {{/if}}
+            {{/inArray}}
+            {{^inArray key ../telmodes}}
+              {{value}}
+            {{/inArray}}
             </span>
           </td>
         </tr>
-        <tr>
-          <td>Email</td>
-          <td>
-            <span>{{contacts.email}}</span>
-          </td>
-        </tr>
-        <tr>
-          <td>Slack ID</td>
-          <td>
-            <span>{{contacts.slack}}</span>
-          </td>
-        </tr>
+        {{/each}}
       </table>
       <button type="submit" id="save-settings" class="btn btn-primary btn-sm pull-right"><span class="btn-text">Save Changes</span> <i class="loader loader-small"></i></button>
     </form>


### PR DESCRIPTION
Makes user settings editable. Disabled by default.
config.yaml boolean setting: "usercontact_ui_readonly" - I could use some suggestions for better naming :)

Other changes:
- Includes changes to show all contact methods from PR: https://github.com/linkedin/oncall/pull/127
- Change user api to work when doing a PUT with both contacts and timezone. INSERTs on a PUT for an existing user caused dup. primary key errors and the logic to retrieve timezone query_data in a mixed timezone+contacts update wasn't working.