### PR TITLE
Add override phone number to teams

### DIFF
--- a/db/dummy_data.sql
+++ b/db/dummy_data.sql
@@ -13,7 +13,7 @@ UNLOCK TABLES;
 
 LOCK TABLES `team` WRITE;
 /*!40000 ALTER TABLE `team` DISABLE KEYS */;
-INSERT INTO `team` VALUES (1,'Test Team','#team','team@example.com','US/Pacific',1,NULL,0);
+INSERT INTO `team` VALUES (1,'Test Team','#team','team@example.com','US/Pacific',1,NULL,0,NULL);
 /*!40000 ALTER TABLE `team` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/db/schema.v0.sql
+++ b/db/schema.v0.sql
@@ -13,6 +13,7 @@ CREATE TABLE IF NOT EXISTS `team` (
   `active` BOOLEAN NOT NULL DEFAULT TRUE,
   `iris_plan` VARCHAR(255),
   `iris_enabled` BOOLEAN NOT NULL DEFAULT FALSE,
+  `override_phone_number` VARCHAR(255),
   PRIMARY KEY (`id`),
   UNIQUE INDEX `name_unique` (`name` ASC));
 

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -62,7 +62,7 @@ def user(request):
 
 
 @pytest.fixture(scope="function")
-def team(request, user):
+def team(request, user, service):
 
     class TeamFactory(object):
 

--- a/src/oncall/api/v0/team.py
+++ b/src/oncall/api/v0/team.py
@@ -13,7 +13,8 @@ from ...utils import load_json_body, invalid_char_reg, create_audit
 from ...constants import TEAM_DELETED, TEAM_EDITED
 
 
-cols = set(['name', 'slack_channel', 'email', 'scheduling_timezone', 'iris_plan', 'iris_enabled'])
+cols = set(['name', 'slack_channel', 'email', 'scheduling_timezone', 'iris_plan', 'iris_enabled',
+             'override_phone_number'])
 
 
 def populate_team_users(cursor, team_dict):
@@ -145,7 +146,7 @@ def on_get(req, resp, team):
 
     connection = db.connect()
     cursor = connection.cursor(db.DictCursor)
-    cursor.execute('SELECT `id`, `name`, `email`, `slack_channel`, `scheduling_timezone`, `iris_plan`, `iris_enabled` '
+    cursor.execute('SELECT `id`, `name`, `email`, `slack_channel`, `scheduling_timezone`, `iris_plan`, `iris_enabled`, `override_phone_number` '
                    'FROM `team` WHERE `name`=%s AND `active` = %s', (team, active))
     results = cursor.fetchall()
     if not results:
@@ -203,7 +204,7 @@ def on_put(req, resp, team):
             raise HTTPBadRequest('invalid team name',
                                  'team name contains invalid character "%s"' % invalid_char.group())
 
-    if 'iris_plan' in data:
+    if 'iris_plan' in data and data['iris_plan']:
         iris_plan = data['iris_plan']
         plan_resp = iris.client.get(iris.client.url + 'plans?name=%s&active=1' % iris_plan)
         if plan_resp.status_code != 200 or plan_resp.json() == []:

--- a/src/oncall/api/v0/teams.py
+++ b/src/oncall/api/v0/teams.py
@@ -149,6 +149,9 @@ def on_post(req, resp):
     email = data.get('email')
     iris_plan = data.get('iris_plan')
     iris_enabled = data.get('iris_enabled', False)
+    override_number = data.get('override_phone_number')
+    if not override_number:
+        override_number = None
 
     # validate Iris plan if provided and Iris is configured
     if iris_plan is not None and iris.client is not None:
@@ -160,8 +163,10 @@ def on_post(req, resp):
     cursor = connection.cursor()
     try:
         cursor.execute('''
-            INSERT INTO `team` (`name`, `slack_channel`, `email`, `scheduling_timezone`, `iris_plan`, `iris_enabled`)
-            VALUES (%s, %s, %s, %s, %s, %s)''', (team_name, slack, email, scheduling_timezone, iris_plan, iris_enabled))
+            INSERT INTO `team` (`name`, `slack_channel`, `email`, `scheduling_timezone`, `iris_plan`, `iris_enabled`,
+                                `override_phone_number`)
+            VALUES (%s, %s, %s, %s, %s, %s, %s)''',
+            (team_name, slack, email, scheduling_timezone, iris_plan, iris_enabled, override_number))
 
         team_id = cursor.lastrowid
         query = '''

--- a/src/oncall/ui/static/js/oncall.js
+++ b/src/oncall/ui/static/js/oncall.js
@@ -750,6 +750,7 @@ var oncall = {
           email = $form.find('#team-email').val(),
           slack = $form.find('#team-slack').val(),
           timezone = $form.find('#team-timezone').val(),
+          overrideNumber = $form.find('#team-override-phone').val(),
           irisPlan = $form.find('#team-irisplan').val(),
           irisEnabled = $form.find('#team-iris-enabled').prop('checked'),
           model = {};
@@ -775,6 +776,7 @@ var oncall = {
               email: email,
               slack_channel: slack,
               scheduling_timezone: timezone,
+              override_phone_number: overrideNumber,
               iris_plan: irisPlan,
               iris_enabled: irisEnabled ? '1' : '0',
               page: self.data.route
@@ -2370,6 +2372,7 @@ var oncall = {
           $teamEmail = $modalForm.find('#team-email'),
           $teamSlack = $modalForm.find('#team-slack'),
           $teamTimezone = $modalForm.find('#team-timezone'),
+          $teamNumber = $modalForm.find('#team-override-phone'),
           $teamIrisPlan = $modalForm.find('#team-irisplan'),
           $teamIrisEnabled = $modalForm.find('#team-iris-enabled'),
           self = this,
@@ -2383,6 +2386,7 @@ var oncall = {
         $teamName.val($btn.attr('data-modal-name'));
         $teamEmail.val($btn.attr('data-modal-email'));
         $teamSlack.val($btn.attr('data-modal-slack'));
+        $teamNumber.val($btn.attr('data-modal-override-phone'));
         $teamIrisPlan.val($btn.attr('data-modal-irisplan'));
         $teamIrisEnabled.prop('checked', $btn.attr('data-modal-iris-enabled') === '1');
         $planInput = $('#team-irisplan');

--- a/src/oncall/ui/templates/base.html
+++ b/src/oncall/ui/templates/base.html
@@ -139,6 +139,9 @@
                 {% endfor %}
               </select>
             </p>
+            <p>
+              <label for="team-override-phone"> Team Override Phone Number: </label> <input type="text" name="override_phone_number" id="team-override-phone" class="form-control" placeholder="Phone Number" />
+            </p>
             {%  if iris_plan_settings.activated %}
             <p>
               <label for="team-irisplan"> Team Iris Escalation Plan:</label>

--- a/src/oncall/ui/templates/index.html
+++ b/src/oncall/ui/templates/index.html
@@ -277,7 +277,7 @@
           <h3>
             {{name}}
             <span class="edit-team-name">
-              <i class="svg-icon svg-icon-pencil" data-toggle="modal" data-target="#team-edit-modal" data-modal-action="oncall.team.updateTeamName" data-modal-title="Update Team Info" data-modal-name="{{#if name}}{{name}}{{else}}{{@key}}{{/if}}" data-modal-email="{{email}}" data-modal-slack="{{slack_channel}}" data-modal-timezone="{{scheduling_timezone}}" data-modal-irisplan="{{iris_plan}}" data-modal-iris-enabled="{{iris_enabled}}" data-admin-action="true">
+              <i class="svg-icon svg-icon-pencil" data-toggle="modal" data-target="#team-edit-modal" data-modal-action="oncall.team.updateTeamName" data-modal-title="Update Team Info" data-modal-name="{{#if name}}{{name}}{{else}}{{@key}}{{/if}}" data-modal-email="{{email}}" data-modal-slack="{{slack_channel}}" data-modal-timezone="{{scheduling_timezone}}" data-modal-irisplan="{{iris_plan}}" data-modal-iris-enabled="{{iris_enabled}}" data-modal-override-phone="{{override_phone_number}}" data-admin-action="true">
                 <svg xmlns="http://www.w3.org/2000/svg" width="16px" height="16px" viewBox="0 0 8 8" style="fill: currentColor">
                   <path d="M6 0l-1 1 2 2 1-1-2-2zm-2 2l-4 4v2h2l4-4-2-2z" />
                 </svg>


### PR DESCRIPTION
Allows teams to configure a phone number that overrides a user's
regular number when they're the current primary on-call. This
lets teams pass around an on-call pager with a single phone
number, for example.