### PR TITLE
ldap sync: allow image_url to be empty

### DIFF
--- a/src/oncall/user_sync/ldap_sync.py
+++ b/src/oncall/user_sync/ldap_sync.py
@@ -243,7 +243,7 @@ def sync(config, engine):
             if full_name != db_contacts.get('full_name'):
                 engine.execute(name_update_sql, (full_name, username))
                 stats['user_names_updated'] += 1
-            if not db_contacts.get('photo_url'):
+            if 'image_url' in LDAP_SETTINGS and not db_contacts.get('photo_url'):
                 photo_url_tpl = LDAP_SETTINGS.get('image_url')
                 photo_url = photo_url_tpl % username if photo_url_tpl else None
                 engine.execute(photo_update_sql, (photo_url, username))

--- a/src/oncall/user_sync/ldap_sync.py
+++ b/src/oncall/user_sync/ldap_sync.py
@@ -212,7 +212,9 @@ def sync(config, engine):
         logger.debug('Inserting %s' % username)
         full_name = ldap_users[username].pop('name')
         try:
-            user_id = engine.execute(user_add_sql, (username, full_name, LDAP_SETTINGS['image_url'] % username)).lastrowid
+            photo_url_tpl = LDAP_SETTINGS.get('image_url')
+            photo_url = photo_url_tpl % username if photo_url_tpl else None
+            user_id = engine.execute(user_add_sql, (username, full_name, photo_url)).lastrowid
         except SQLAlchemyError:
             stats['users_failed_to_add'] += 1
             stats['sql_errors'] += 1
@@ -242,7 +244,9 @@ def sync(config, engine):
                 engine.execute(name_update_sql, (full_name, username))
                 stats['user_names_updated'] += 1
             if not db_contacts.get('photo_url'):
-                engine.execute(photo_update_sql, (LDAP_SETTINGS['image_url'] % username, username))
+                photo_url_tpl = LDAP_SETTINGS.get('image_url')
+                photo_url = photo_url_tpl % username if photo_url_tpl else None
+                engine.execute(photo_update_sql, (photo_url, username))
                 stats['user_photos_updated'] += 1
             for mode in modes:
                 if mode in ldap_contacts and ldap_contacts[mode]:


### PR DESCRIPTION
To resolve https://github.com/linkedin/oncall/issues/80
Which addresses  the comments in the original PR and adds a fix to deal with contact updating as well. https://github.com/linkedin/oncall/issues/80