### PR TITLE
zsh doesnt like unquoted globbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Development setup
 
 ```bash
 python setup.py develop
-pip install -e .[dev]
+pip install -e '.[dev]'
 ```
 
 Setup mysql schema:


### PR DESCRIPTION
Fails with: zsh: no matches found: .[dev]

Which in turn never fails to confuse me.