### PR TITLE
Include oncall static files in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include src/oncall/ui/templates *
+recursive-include src/oncall/ui/static *


### PR DESCRIPTION
when oncall is installed with `pip install` ui static files are missing.