### PR TITLE
don't use ldaps if there's no cert file in the config

### DIFF
--- a/src/oncall/auth/modules/ldap_example.py
+++ b/src/oncall/auth/modules/ldap_example.py
@@ -19,6 +19,8 @@ class Authenticator:
             if not os.access(self.cert_path, os.R_OK):
                 logger.error("Failed to read ldap_cert_path certificate")
                 raise IOError
+        else:
+            self.cert_path = None
 
         self.bind_user = config.get('ldap_bind_user')
         self.bind_password = config.get('ldap_bind_password')
@@ -30,7 +32,8 @@ class Authenticator:
         self.user_suffix = config.get('ldap_user_suffix')
 
     def ldap_auth(self, username, password):
-        ldap.set_option(ldap.OPT_X_TLS_CACERTFILE, self.cert_path)
+        if self.cert_path:
+            ldap.set_option(ldap.OPT_X_TLS_CACERTFILE, self.cert_path)
 
         connection = ldap.initialize(self.ldap_url)
         connection.set_option(ldap.OPT_REFERRALS, 0)

--- a/src/oncall/auth/modules/ldap_import.py
+++ b/src/oncall/auth/modules/ldap_import.py
@@ -21,6 +21,8 @@ class Authenticator:
             if not os.access(self.cert_path, os.R_OK):
                 logger.error("Failed to read ldap_cert_path certificate")
                 raise IOError
+        else:
+            self.cert_path = None
 
         self.bind_user = config.get('ldap_bind_user')
         self.bind_password = config.get('ldap_bind_password')
@@ -34,7 +36,8 @@ class Authenticator:
         self.attrs = config.get('attrs')
 
     def ldap_auth(self, username, password):
-        ldap.set_option(ldap.OPT_X_TLS_CACERTFILE, self.cert_path)
+        if self.cert_path:
+            ldap.set_option(ldap.OPT_X_TLS_CACERTFILE, self.cert_path)
 
         connection = ldap.initialize(self.ldap_url)
         connection.set_option(ldap.OPT_REFERRALS, 0)


### PR DESCRIPTION
Not all organizations implement ldaps, so it doesn't make sense to always enforce it.