### PR TITLE
team name change on deletion

### DIFF
--- a/db/schema.v0.sql
+++ b/db/schema.v0.sql
@@ -18,6 +18,17 @@ CREATE TABLE IF NOT EXISTS `team` (
   UNIQUE INDEX `name_unique` (`name` ASC));
 
 -- -----------------------------------------------------
+-- Table `deleted_teams`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `deleted_teams` (
+  `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `new_name` VARCHAR(255) NOT NULL,
+  `old_name` VARCHAR(255) NOT NULL,
+  `deletion_date` DATE NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE INDEX `new_name_unique` (`new_name` ASC));
+
+-- -----------------------------------------------------
 -- Table `user`
 -- -----------------------------------------------------
 CREATE TABLE IF NOT EXISTS `user` (

--- a/db/schema.v0.sql
+++ b/db/schema.v0.sql
@@ -18,14 +18,19 @@ CREATE TABLE IF NOT EXISTS `team` (
   UNIQUE INDEX `name_unique` (`name` ASC));
 
 -- -----------------------------------------------------
--- Table `deleted_teams`
+-- Table `deleted_team`
 -- -----------------------------------------------------
-CREATE TABLE IF NOT EXISTS `deleted_teams` (
-  `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+CREATE TABLE IF NOT EXISTS `deleted_team` (
+  `team_id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
   `new_name` VARCHAR(255) NOT NULL,
   `old_name` VARCHAR(255) NOT NULL,
-  `deletion_date` DATE NOT NULL,
-  PRIMARY KEY (`id`),
+  `deletion_date` BIGINT(20) NOT NULL,
+  PRIMARY KEY (`team_id`),
+  CONSTRAINT `deleted_team_team_fk`
+    FOREIGN KEY (`team_id`)
+    REFERENCES `team` (`id`)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE,
   UNIQUE INDEX `new_name_unique` (`new_name` ASC));
 
 -- -----------------------------------------------------

--- a/src/oncall/api/v0/team.py
+++ b/src/oncall/api/v0/team.py
@@ -1,7 +1,7 @@
 # Copyright (c) LinkedIn Corporation. All rights reserved. Licensed under the BSD-2 Clause license.
 # See LICENSE in the project root for license information.
 import uuid
-import datetime
+import time
 from urllib import unquote
 from falcon import HTTPNotFound, HTTPBadRequest, HTTPError
 from ujson import dumps as json_dumps
@@ -245,8 +245,8 @@ def on_delete(req, resp, team):
     :statuscode 404: Team not found
     '''
     team = unquote(team)
-    new_team = team + '-' + str(uuid.uuid1())
-    deletion_date = datetime.datetime.today().strftime('%Y-%m-%d')
+    new_team = str(uuid.uuid4())
+    deletion_date = time.time()
     check_team_auth(team, req)
     connection = db.connect()
     cursor = connection.cursor()
@@ -257,16 +257,15 @@ def on_delete(req, resp, team):
     create_audit({}, team, TEAM_DELETED, req, cursor)
     deleted = cursor.rowcount
 
-    # keep new team name under 255 characters
-    if len(team) > 216:
-        new_team = team[:216] + '-' + str(uuid.uuid1())
+    if deleted == 0:
+        raise HTTPNotFound()
+
+    cursor.execute('SELECT `id` FROM `team` WHERE `name`=%s', team)
+    team_id = cursor.fetchone()
 
     # create entry in deleted_teams and then change name in team to preserve a clean namespace
     cursor.execute('UPDATE `team` SET `name` = %s WHERE `name`= %s', (new_team, team))
-    cursor.execute('INSERT INTO `deleted_teams` (new_name, old_name, deletion_date) VALUES (%s, %s, %s)', (new_team, team, deletion_date))
+    cursor.execute('INSERT INTO `deleted_team` (team_id, new_name, old_name, deletion_date) VALUES (%s, %s, %s, %s)', (team_id, new_team, team, deletion_date))
     connection.commit()
     cursor.close()
     connection.close()
-
-    if deleted == 0:
-        raise HTTPNotFound()

--- a/src/oncall/api/v0/team.py
+++ b/src/oncall/api/v0/team.py
@@ -258,6 +258,9 @@ def on_delete(req, resp, team):
     deleted = cursor.rowcount
 
     if deleted == 0:
+        connection.commit()
+        cursor.close()
+        connection.close()
         raise HTTPNotFound()
 
     cursor.execute('SELECT `id` FROM `team` WHERE `name`=%s', team)

--- a/src/oncall/api/v0/team.py
+++ b/src/oncall/api/v0/team.py
@@ -1,6 +1,7 @@
 # Copyright (c) LinkedIn Corporation. All rights reserved. Licensed under the BSD-2 Clause license.
 # See LICENSE in the project root for license information.
-
+import uuid
+import datetime
 from urllib import unquote
 from falcon import HTTPNotFound, HTTPBadRequest, HTTPError
 from ujson import dumps as json_dumps
@@ -244,6 +245,8 @@ def on_delete(req, resp, team):
     :statuscode 404: Team not found
     '''
     team = unquote(team)
+    new_team = team + '-' + str(uuid.uuid1())
+    deletion_date = datetime.datetime.today().strftime('%Y-%m-%d')
     check_team_auth(team, req)
     connection = db.connect()
     cursor = connection.cursor()
@@ -253,6 +256,14 @@ def on_delete(req, resp, team):
                    'AND `start` > UNIX_TIMESTAMP()', team)
     create_audit({}, team, TEAM_DELETED, req, cursor)
     deleted = cursor.rowcount
+
+    # keep new team name under 255 characters
+    if len(team) > 216:
+        new_team = team[:216] + '-' + str(uuid.uuid1())
+
+    # create entry in deleted_teams and then change name in team to preserve a clean namespace
+    cursor.execute('UPDATE `team` SET `name` = %s WHERE `name`= %s', (new_team, team))
+    cursor.execute('INSERT INTO `deleted_teams` (new_name, old_name, deletion_date) VALUES (%s, %s, %s)', (new_team, team, deletion_date))
     connection.commit()
     cursor.close()
     connection.close()


### PR DESCRIPTION
When teams are deleted change their names to uuids to avoid future namespace conflict. Add new table to keep track of changes for auditing.