### PR TITLE
Vacation makes users unavailable across teams

### DIFF
--- a/e2e/test_populate.py
+++ b/e2e/test_populate.py
@@ -59,6 +59,54 @@ def test_api_v0_populate_new(user, team, roster, role, schedule):
     clean_up()
 
 
+@prefix('test_v0_populate_vacation_propagate')
+def test_v0_populate_vacation_propagate(user, team, roster, role, schedule, event):
+    user_name = user.create()
+    user_name_2 = user.create()
+    team_name = team.create()
+    team_name_2 = team.create()
+    role_name = role.create()
+    roster_name = roster.create(team_name)
+    schedule_id = schedule.create(team_name,
+                                  roster_name,
+                                  {'role': role_name,
+                                   'events': [{'start': 0, 'duration': 604800}],
+                                   'advanced_mode': 0,
+                                   'auto_populate_threshold': 14})
+    user.add_to_roster(user_name, team_name, roster_name)
+    user.add_to_roster(user_name_2, team_name, roster_name)
+    user.add_to_team(user_name, team_name_2)
+
+    # Populate for team 1
+    re = requests.post(api_v0('schedules/%s/populate' % schedule_id), json = {'start': time.time()})
+    assert re.status_code == 200
+
+    # Create conflicting vacation event in team 2 for user 1
+    re = requests.get(api_v0('events?team=%s' % team_name))
+    assert re.status_code == 200
+    events = re.json()
+    assert len(events) == 2
+    assert events[0]['user'] != events[1]['user']
+    for e in events:
+        event.create({
+            'start': e['start'],
+            'end': e['end'],
+            'user': user_name,
+            'team': team_name_2,
+            'role': "vacation",
+        })
+
+    # Populate again for team 1
+    re = requests.post(api_v0('schedules/%s/populate' % schedule_id), json = {'start': time.time()})
+    assert re.status_code == 200
+
+    # Ensure events are both for user 2 (since user 1 is busy in team 2)
+    re = requests.get(api_v0('events?team=%s&include_subscribed=false' % team_name))
+    assert re.status_code == 200
+    events = re.json()
+    assert len(events) == 2
+    assert events[0]['user'] == events[1]['user'] == user_name_2
+
 @prefix('test_v0_populate_over')
 def test_api_v0_populate_over(user, team, roster, role, schedule):
     user_name = user.create()

--- a/src/oncall/api/v0/preview.py
+++ b/src/oncall/api/v0/preview.py
@@ -34,7 +34,7 @@ def on_get(req, resp, schedule_id):
     # create a temporary table with the events that include members of the team's roster
     query = '''
             CREATE TEMPORARY TABLE IF NOT EXISTS `temp_event` AS
-            (SELECT `event`.*
+            (SELECT `event`.`id`, `event`.`team_id`, `event`.`role_id`, `event`.`schedule_id`, `event`.`link_id`, `event`.`user_id`, `event`.`start`, `event`.`end`, `event`.`note`
             FROM `event`
             INNER JOIN `roster_user`
             ON `event`.`user_id`=`roster_user`.`user_id`

--- a/src/oncall/scheduler/default.py
+++ b/src/oncall/scheduler/default.py
@@ -83,10 +83,6 @@ class Scheduler(object):
                        team_id)
         subscriptions = cursor.fetchall()
         team_check = ['team_id = %s']
-
-        cursor.execute("SELECT `id` FROM `role` WHERE `name` = 'vacation'")
-        vacation_role_id = cursor.fetchone()['id']
-
         query_params.append(team_id)
         for sub in subscriptions:
             team_check.append('(team_id = %s AND role_id = %s)')
@@ -94,8 +90,8 @@ class Scheduler(object):
 
         query = '''
                 SELECT DISTINCT `user_id` FROM `%s`
-                WHERE `user_id` in %%s AND (%s) AND (%s or `role_id`= %s)
-                ''' % (table_name, ' OR '.join(range_check), ' OR '.join(team_check), vacation_role_id)
+                WHERE `user_id` in %%s AND (%s) AND (%s or `role_id`= (SELECT `id` FROM `role` WHERE `name` = 'vacation'))
+                ''' % (table_name, ' OR '.join(range_check), ' OR '.join(team_check))
 
         cursor.execute(query, query_params)
         return [r['user_id'] for r in cursor.fetchall()]

--- a/src/oncall/scheduler/default.py
+++ b/src/oncall/scheduler/default.py
@@ -83,6 +83,10 @@ class Scheduler(object):
                        team_id)
         subscriptions = cursor.fetchall()
         team_check = ['team_id = %s']
+
+        cursor.execute("SELECT `id` FROM `role` WHERE `name` = 'vacation'")
+        vacation_role_id = cursor.fetchone()['id']
+
         query_params.append(team_id)
         for sub in subscriptions:
             team_check.append('(team_id = %s AND role_id = %s)')
@@ -90,8 +94,8 @@ class Scheduler(object):
 
         query = '''
                 SELECT DISTINCT `user_id` FROM `%s`
-                WHERE `user_id` in %%s AND (%s) AND (%s or `role_id`=5)
-                ''' % (table_name, ' OR '.join(range_check), ' OR '.join(team_check))
+                WHERE `user_id` in %%s AND (%s) AND (%s or `role_id`= %s)
+                ''' % (table_name, ' OR '.join(range_check), ' OR '.join(team_check), vacation_role_id)
 
         cursor.execute(query, query_params)
         return [r['user_id'] for r in cursor.fetchall()]


### PR DESCRIPTION
- a vacation event will now make a user unavailable across all the teams he is part of, even if that vacation event is only in one teams calendar

- temporary table now only copies events that involve members in the schedule's roster