### PR TITLE
mysql 8 breaks Authentication plugin 'caching_sha2_password'

### DIFF
--- a/docs/source/admin_guide.rst
+++ b/docs/source/admin_guide.rst
@@ -17,7 +17,7 @@ A local test instance of Oncall can be setup with Docker_ in a few commands:
     mkdir output
     python gen_packer_cfg.py ./oncall.yaml | tail -n +2 > ./output/oncall.json
     packer build -only=docker oncall.json
-    docker run -d --name oncall-mysql -e MYSQL_ROOT_PASSWORD='1234' mysql
+    docker run -d --name oncall-mysql -e MYSQL_ROOT_PASSWORD='1234' mysql:5.7
     docker run -d --link oncall-mysql:mysql -p 8080:8080 -e DOCKER_DB_BOOTSTRAP=1 quay.io/iris/oncall
 
 .. NOTE::


### PR DESCRIPTION
https://github.com/docker-library/mysql/issues/419
ERROR 2059 (HY000): Authentication plugin 'caching_sha2_password' cannot be loaded
Resolve by explicitly testing with mysql5.7 docker image... there are other ways around it but this guide is for devs to test quickly.