### PR TITLE
 change preview date behavior to match populate behavior

### DIFF
--- a/src/oncall/scheduler/default.py
+++ b/src/oncall/scheduler/default.py
@@ -386,7 +386,9 @@ class Scheduler(object):
             start_epoch += timedelta(weeks=period)
             handoff += timedelta(weeks=period)
         if handoff < utc.localize(datetime.utcnow()):
-            raise HTTPBadRequest('Invalid populate request', 'cannot populate starting in the past')
+            cursor.execute("DROP TEMPORARY TABLE IF EXISTS `temp_event`")
+            connection.commit()
+            raise HTTPBadRequest('Invalid populate/preview request', 'cannot populate/preview starting in the past')
 
         future_events, last_epoch = self.calculate_future_events(schedule, cursor, start_epoch)
         self.set_last_epoch(schedule['id'], last_epoch, cursor)

--- a/src/oncall/ui/static/js/incalendar.js
+++ b/src/oncall/ui/static/js/incalendar.js
@@ -49,6 +49,9 @@
           onEventAlways: function(){
             // callback for when fetch events ajax call is completed run regardless of success or failure
           },
+          onFetchFail: function(data){
+            // callback for when fetch calendar events fails
+          },
           onAddEvents: function (events) {
             // callback for when events are added to calendar
           },
@@ -679,6 +682,8 @@
         self.options.events = data;
         self.addCalendarEvents();
         self.options.onEventGet(data, self.$calendar);
+      }).fail(function(data){
+        self.options.onFetchFail(data);
       }).always(function(){
         self.$el.removeClass('loading-events');
         self.options.onEventAlways();

--- a/src/oncall/ui/static/js/oncall.js
+++ b/src/oncall/ui/static/js/oncall.js
@@ -2228,8 +2228,6 @@ var oncall = {
 
           if ( isNaN(Date.parse(date)) ) {
             oncall.alerts.createAlert('Invalid date.', 'danger', $modal.find('.modal-body'));
-          } else if (date <= new Date()) {
-            oncall.alerts.createAlert('Invalid date. Can only preview events in the future.', 'danger', $modal.find('.modal-body'));
           } else {
             self.populatePreview(date.valueOf(), $(this), $modal);
           }
@@ -2260,7 +2258,11 @@ var oncall = {
             persistSettings: false,
             onEventGet: function(events, $cal){
               $cal.find('[data-schedule-id="' + scheduleId + '"]').attr('data-highlighted', true);
-            }
+            },
+            onEventAlways: function(){
+            },
+            onFetchFail: function(data){
+            },
           });
         }).fail(function(data){
           var error = oncall.isJson(data.responseText) ? JSON.parse(data.responseText).description : data.responseText || 'Populate failed.';
@@ -2288,7 +2290,11 @@ var oncall = {
           },
           onEventAlways: function(){
             $cta.removeClass('loading disabled').prop('disabled', false);
-          }
+          },
+          onFetchFail: function(data){
+            var error = oncall.isJson(data.responseText) ? JSON.parse(data.responseText).description : data.responseText || 'Preview failed.';
+            oncall.alerts.createAlert(error, 'danger', $modal.find('.modal-body'));
+          },
         });
       },
       getSchedulerData: function($form) {


### PR DESCRIPTION
preview function will now fail based on past dates in the same way populate does i.e (handoff < utc.localize(datetime.utcnow())) as opposed to automatically rejecting any dates that didn't start from the next day onwards