### PR TITLE
Fix today button behavior

### DIFF
--- a/src/oncall/ui/static/js/incalendar.js
+++ b/src/oncall/ui/static/js/incalendar.js
@@ -232,7 +232,12 @@
               if (todayBtn) {
                 return $('<button id="inc-controls-today" class="btn btn-blue">Today</button>')
                         .click(function () {
-                          self.stepToDate(moment());
+                          if(moment().isAfter(self.options.today, 'day')){
+                            location.reload();
+                          }
+                          else{
+                            self.stepToDate(self.options.today);
+                          }
                         });
               }
             }

--- a/src/oncall/ui/static/js/incalendar.js
+++ b/src/oncall/ui/static/js/incalendar.js
@@ -232,7 +232,7 @@
               if (todayBtn) {
                 return $('<button id="inc-controls-today" class="btn btn-blue">Today</button>')
                         .click(function () {
-                          self.stepToDate(self.options.today);
+                          self.stepToDate(moment());
                         });
               }
             }


### PR DESCRIPTION
If page was loaded more than a day ago clicking the today button will reload the page to get the most current data. Fixes today button highlighting old dates.