### PR TITLE
Update notifier exception handling

### DIFF
--- a/src/oncall/bin/notifier.py
+++ b/src/oncall/bin/notifier.py
@@ -118,7 +118,7 @@ def format_and_send_message():
     msg['body'] = msg_info['body'] % context
     try:
         send_message(msg)
-    except:
+    except Exception:
         logger.exception('Failed to send message %s', msg)
         mark_message_as_unsent(msg_info)
         metrics.stats['message_fail_cnt'] += 1

--- a/src/oncall/messengers/iris_messenger.py
+++ b/src/oncall/messengers/iris_messenger.py
@@ -13,5 +13,11 @@ class iris_messenger(object):
         self.iris_client = IrisClient(config['application'], config['iris_api_key'], config['api_host'])
 
     def send(self, message):
-        self.iris_client.notification(role='user', target=message['user'], priority=message.get('priority'),
-                                      mode=message.get('mode'), subject=message['subject'], body=message['body'])
+        try:
+            self.iris_client.notification(role='user', target=message['user'], priority=message.get('priority'),
+                                          mode=message.get('mode'), subject=message['subject'], body=message['body'])
+        except ValueError as e:
+            if 'INVALID role:target' not in e.args[0]:
+                raise e
+        except Exception as e:
+            raise e


### PR DESCRIPTION
Ignore role:target lookup failures from Iris, since these don't represent
problems with the underlying system, just that people have inactive users
on-call in the future.