### PR TITLE
Pin slackclient to version 1.3.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
         'python-ldap',
         'pytz',
         'irisclient',
-        'slackclient',
+        'slackclient==1.3.1',
         'icalendar',
         'pymsteams'
     ],


### PR DESCRIPTION
In #251 User avutu noted that a fresh install will fail because an upstream requirement of the slackclient package requires python 3. User Linearhero found that version 1.3.1 maintains python 2
compatibility.