### PR TITLE
Copying README.md to docker build context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN useradd -m -s /bin/bash oncall
 COPY src /home/oncall/source/src
 COPY setup.py /home/oncall/source/setup.py
 COPY MANIFEST.in /home/oncall/source/MANIFEST.in
+COPY README.md /home/oncall/source/README.md
 
 WORKDIR /home/oncall
 


### PR DESCRIPTION
The README.md file is being read to populate the long_description field in setup.py. Currently since the README.md file is not present in the docker build context, the step executing `pip install .` is failing with the "No Such File or Directory" error message. As part of this PR, I'm copying the README.md file to the docker build context. Verified that `docker-compose up` is working fine after this change.

fixes #300 