### PR TITLE
filter events for calendar by end time rather than start time

### DIFF
--- a/src/oncall/api/v0/public_ical.py
+++ b/src/oncall/api/v0/public_ical.py
@@ -25,7 +25,7 @@ def on_get(req, resp, key):
     if type == 'user':
         events = get_user_events(name, start)
     elif type == 'team':
-        events = get_team_events(name, start)
+        events = get_team_events(name, start, include_subscribed=True)
     else:                       # should not happen
         events = []
 

--- a/src/oncall/api/v0/team_ical.py
+++ b/src/oncall/api/v0/team_ical.py
@@ -25,7 +25,7 @@ def get_team_events(team, start):
             JOIN `user` ON `event`.`user_id` = `user`.`id`
             JOIN `role` ON `event`.`role_id` = `role`.`id`
         WHERE
-            `event`.`start` > %s AND
+            `event`.`end` > %s AND
             `team`.`name` = %s
         ''',
         (start, team))

--- a/src/oncall/api/v0/team_ical.py
+++ b/src/oncall/api/v0/team_ical.py
@@ -7,12 +7,26 @@ from . import ical
 from ... import db
 
 
-def get_team_events(team, start):
+def get_team_events(team, start, include_subscribed=False):
     connection = db.connect()
     cursor = connection.cursor(db.DictCursor)
 
-    cursor.execute(
-        '''
+    team_condition = "`team`.`name` = %s"
+    if include_subscribed:
+        cursor.execute(
+            '''
+            SELECT `subscription_id`, `role_id`
+            FROM `team_subscription`
+            JOIN `team` ON `team_id` = `team`.`id`
+            WHERE `team`.`name` = %s
+            ''', team)
+        if cursor.rowcount != 0:
+            subscriptions = ' OR '.join(['(`team`.`id` = %s AND `role`.`id` = %s)' %
+                                         (row['subscription_id'], row['role_id'])
+                                         for row in cursor])
+            team_condition = '(%s OR (%s))' % (team_condition, subscriptions)
+
+    query = '''
         SELECT
             `event`.`id`,
             `team`.`name` AS team,
@@ -26,9 +40,10 @@ def get_team_events(team, start):
             JOIN `role` ON `event`.`role_id` = `role`.`id`
         WHERE
             `event`.`end` > %s AND
-            `team`.`name` = %s
-        ''',
-        (start, team))
+        ''' + team_condition
+
+    cursor.execute(
+        query, (start, team))
 
     events = cursor.fetchall()
     cursor.close()
@@ -58,7 +73,10 @@ def on_get(req, resp, team):
     contact = req.get_param_as_bool('contact')
     if contact is None:
         contact = True
+    include_sub = req.get_param_as_bool('include_subscribed')
+    if include_sub is None:
+        include_sub = True
 
-    events = get_team_events(team, start)
+    events = get_team_events(team, start, include_subscribed=include_sub)
     resp.body = ical.events_to_ical(events, team, contact)
     resp.set_header('Content-Type', 'text/calendar')

--- a/src/oncall/api/v0/user_ical.py
+++ b/src/oncall/api/v0/user_ical.py
@@ -24,7 +24,7 @@ def get_user_events(user_name, start):
             JOIN `user` ON `event`.`user_id` = `user`.`id`
             JOIN `role` ON `event`.`role_id` = `role`.`id`
         WHERE
-            `event`.`start` > %s AND
+            `event`.`end` > %s AND
             `user`.`name` = %s
         ''',
         (start, user_name))


### PR DESCRIPTION
If the user request for the calendar if the middle of an event, we can
now show the event (it did not show up because start time is after the
current time).