### PR TITLE
check if team exists and is active when creating a new key

### DIFF
--- a/src/oncall/api/v0/ical_key.py
+++ b/src/oncall/api/v0/ical_key.py
@@ -10,6 +10,27 @@ def generate_ical_key():
     return str(uuid.uuid4())
 
 
+def check_ical_team(team, requester):
+    """
+    Currently we allow users to request ical key for any team calendar
+    """
+    connection = db.connect()
+    cursor = connection.cursor()
+
+    cursor.execute(
+        '''
+        SELECT `id`
+        FROM `team`
+        WHERE `name` = %s AND `active` = TRUE
+        ''',
+        (team, ))
+    team_exist_and_active = cursor.rowcount
+
+    cursor.close()
+    connection.close()
+    return team_exist_and_active != 0
+
+
 def check_ical_key_requester(key, requester):
     connection = db.connect()
     cursor = connection.cursor()

--- a/src/oncall/api/v0/ical_key_team.py
+++ b/src/oncall/api/v0/ical_key_team.py
@@ -1,19 +1,22 @@
 # Copyright (c) LinkedIn Corporation. All rights reserved. Licensed under the BSD-2 Clause license.
 # See LICENSE in the project root for license information.
 
-from falcon import HTTPNotFound, HTTP_201
+from falcon import HTTPNotFound, HTTPBadRequest, HTTP_201
 
-from ...auth import login_required, check_calendar_auth
-from .ical_key import get_ical_key, update_ical_key, delete_ical_key, generate_ical_key
+from ...auth import login_required
+from .ical_key import (
+    get_ical_key,
+    update_ical_key,
+    delete_ical_key,
+    generate_ical_key,
+    check_ical_team,
+)
 
 
 @login_required
 def on_get(req, resp, team):
     """Get the secret key that grants public access to team's oncall
     calendar for the logged-in user.
-
-    Current policy only allows access to the team that the logged-in
-    user is part of.
 
     **Example request:**
 
@@ -26,7 +29,6 @@ def on_get(req, resp, team):
 
     """
     challenger = req.context['user']
-    check_calendar_auth(team, req)
 
     key = get_ical_key(challenger, team, 'team')
     if key is None:
@@ -41,12 +43,13 @@ def on_post(req, resp, team):
     """Update or create the secret key that grants public access to team's
     oncall calendar for the logged-in user.
 
-    Current policy only allows access to the team that the logged-in
-    user is part of.
-
     """
     challenger = req.context['user']
-    check_calendar_auth(team, req)
+    if not check_ical_team(team, challenger):
+        raise HTTPBadRequest(
+            'Invalid team name',
+            'Team "%s" does not exist or is inactive' % team,
+        )
 
     key = generate_ical_key()
     update_ical_key(challenger, team, 'team', key)
@@ -61,11 +64,7 @@ def on_delete(req, resp, team):
     """Delete the secret key that grants public access to team's oncall
     calendar for the logged-in user.
 
-    Current policy only allows access to the team that the logged-in
-    user is part of.
-
     """
     challenger = req.context['user']
-    check_calendar_auth(team, req)
 
     delete_ical_key(challenger, team, 'team')


### PR DESCRIPTION
Loosen team ical key request: do not check team membership