### PR TITLE
filter oncall calendar by roles

### DIFF
--- a/src/oncall/api/v0/public_ical.py
+++ b/src/oncall/api/v0/public_ical.py
@@ -16,18 +16,19 @@ def on_get(req, resp, key):
     information.  Key can be requested at /api/v0/ical_key.
 
     """
+    roles = req.get_param_as_list('roles')
+
     name_and_type = get_name_and_type_from_key(key)
     if name_and_type is None:
         raise HTTPNotFound()
 
     name, type = name_and_type
     start = int(time.time())
+    events = []
     if type == 'user':
-        events = get_user_events(name, start)
+        events = get_user_events(name, start, roles=roles)
     elif type == 'team':
-        events = get_team_events(name, start, include_subscribed=True)
-    else:                       # should not happen
-        events = []
+        events = get_team_events(name, start, roles=roles, include_subscribed=True)
 
     resp.body = ical.events_to_ical(events, name, contact=False)
     resp.set_header('Content-Type', 'text/calendar')

--- a/src/oncall/api/v0/roles.py
+++ b/src/oncall/api/v0/roles.py
@@ -31,6 +31,17 @@ constraints = {
 }
 
 
+def get_role_ids(cursor, roles):
+    if not roles:
+        return []
+
+    role_query = 'SELECT DISTINCT `id` FROM `role` WHERE `name` IN ({0})'.format(
+        ','.join(['%s'] * len(roles)))
+    # we need prepared statements here because roles come from user input
+    cursor.execute(role_query, roles)
+    return [row['id'] for row in cursor]
+
+
 def on_get(req, resp):
     """
     Role search.

--- a/src/oncall/api/v0/team_ical.py
+++ b/src/oncall/api/v0/team_ical.py
@@ -3,7 +3,7 @@
 
 import time
 from . import ical
-
+from .roles import get_role_ids
 from ... import db
 
 
@@ -12,14 +12,10 @@ def get_team_events(team, start, roles=None, include_subscribed=False):
     cursor = connection.cursor(db.DictCursor)
 
     role_condition = ''
-    if roles:
-        role_query = 'SELECT DISTINCT `id` FROM `role` WHERE `name` IN ({0})'.format(
-            ','.join(['%s'] * len(roles)))
-        # we need prepared statements here because roles come from user input
-        cursor.execute(role_query, roles)
-        if cursor.rowcount != 0:
-            role_condition = ' AND `event`.`role_id` IN ({0})'.format(
-                ','.join([str(row['id']) for row in cursor]))
+    role_ids = get_role_ids(cursor, roles)
+    if role_ids:
+        role_condition = ' AND `event`.`role_id` IN ({0})'.format(
+            ','.join(map(str, role_ids)))
 
     team_condition = "`team`.`name` = %s"
     if include_subscribed:

--- a/src/oncall/api/v0/user_ical.py
+++ b/src/oncall/api/v0/user_ical.py
@@ -3,6 +3,7 @@
 
 import time
 from . import ical
+from .roles import get_role_ids
 from ... import db
 
 
@@ -11,14 +12,10 @@ def get_user_events(user_name, start, roles=None):
     cursor = connection.cursor(db.DictCursor)
 
     role_condition = ''
-    if roles:
-        role_query = 'SELECT DISTINCT `id` FROM `role` WHERE `name` IN ({0})'.format(
-            ','.join(['%s'] * len(roles)))
-        # we need prepared statements here because roles come from user input
-        cursor.execute(role_query, roles)
-        if cursor.rowcount != 0:
-            role_condition = ' AND `event`.`role_id` IN ({0})'.format(
-                ','.join([str(row['id']) for row in cursor]))
+    role_ids = get_role_ids(cursor, roles)
+    if role_ids:
+        role_condition = ' AND `event`.`role_id` IN ({0})'.format(
+            ','.join(map(str, role_ids)))
 
     query = '''
         SELECT


### PR DESCRIPTION
1. added role filtering to user/team calendar events
2. pass along roles from url parameters

Users can now add url param `roles` like `roles=primary,vacation` where `roles` should be a comma separated list (for a list of roles refer to UI or https://github.com/linkedin/oncall/blob/v1.2.2/db/schema.v0.sql#L137-L142).