### PR TITLE
Add slack channel notifications

### DIFF
--- a/db/dummy_data.sql
+++ b/db/dummy_data.sql
@@ -13,7 +13,7 @@ UNLOCK TABLES;
 
 LOCK TABLES `team` WRITE;
 /*!40000 ALTER TABLE `team` DISABLE KEYS */;
-INSERT INTO `team` VALUES (1,'Test Team','#team','team@example.com','US/Pacific',1,NULL,0,NULL);
+INSERT INTO `team` VALUES (1,'Test Team','#team','#team-alerts','team@example.com','US/Pacific',1,NULL,0,NULL);
 /*!40000 ALTER TABLE `team` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/db/schema-update.v0-1602184489.sql
+++ b/db/schema-update.v0-1602184489.sql
@@ -1,0 +1,6 @@
+-- -----------------------------------------------------
+-- Update to Table `team`
+-- -----------------------------------------------------
+
+ALTER TABLE `team`
+  ADD COLUMN IF NOT EXISTS slack_channel_notifications VARCHAR(255);

--- a/db/schema.v0.sql
+++ b/db/schema.v0.sql
@@ -8,6 +8,7 @@ CREATE TABLE IF NOT EXISTS `team` (
   `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
   `name` VARCHAR(255) NOT NULL,
   `slack_channel` VARCHAR(255),
+  `slack_channel_notifications` VARCHAR(255),
   `email` VARCHAR(255),
   `scheduling_timezone` VARCHAR(255),
   `active` BOOLEAN NOT NULL DEFAULT TRUE,

--- a/e2e/test_audit.py
+++ b/e2e/test_audit.py
@@ -27,7 +27,7 @@ def test_audit(team, user, role, roster, event):
     # test team actions
     start = int(time.time())
     team_name_2 = team.create()
-    requests.put(api_v0('teams/'+team_name_2), json={'email': 'foo', 'slack_channel': 'bar'})
+    requests.put(api_v0('teams/'+team_name_2), json={'email': 'foo', 'slack_channel': 'bar', 'slack_channel_notifications': 'bar-alerts'})
     requests.delete(api_v0('teams/%s' % team_name_2))
     end = time.time()
     audit = get_audit_log(start, end)

--- a/e2e/test_audit.py
+++ b/e2e/test_audit.py
@@ -27,7 +27,7 @@ def test_audit(team, user, role, roster, event):
     # test team actions
     start = int(time.time())
     team_name_2 = team.create()
-    requests.put(api_v0('teams/'+team_name_2), json={'email': 'foo', 'slack_channel': 'bar', 'slack_channel_notifications': 'bar-alerts'})
+    requests.put(api_v0('teams/'+team_name_2), json={'email': 'foo', 'slack_channel': '#bar', 'slack_channel_notifications': '#bar-alerts'})
     requests.delete(api_v0('teams/%s' % team_name_2))
     end = time.time()
     audit = get_audit_log(start, end)

--- a/e2e/test_teams.py
+++ b/e2e/test_teams.py
@@ -103,7 +103,7 @@ def test_api_v0_update_team(team):
     re = requests.put(api_v0('teams/'+team_name), json={'name': new_team_name,
                                                         'email': email,
                                                         'slack_channel': slack,
-                                                        'slack_channel_notificationse': slack_notifications,
+                                                        'slack_channel_notifications': slack_notifications,
                                                         'override_phone_number': override_num})
     assert re.status_code == 200
     team.mark_for_cleaning(new_team_name)

--- a/e2e/test_teams.py
+++ b/e2e/test_teams.py
@@ -87,8 +87,8 @@ def test_api_v0_update_team(team):
     team_name = team.create()
     new_team_name = "new-moninfra-update"
     email = 'abc@gmail.com'
-    slack = '#slack'
-    slack_notifications = '#slack-alerts'
+    slack = 'slack'
+    slack_notifications = 'slack-alerts'
 
     override_num = '1234'
 

--- a/e2e/test_teams.py
+++ b/e2e/test_teams.py
@@ -58,7 +58,7 @@ def test_api_v0_get_team(team, role, roster, schedule):
     assert re.status_code == 200
     team = re.json()
     assert isinstance(team, dict)
-    expected_set = {'users', 'admins', 'services', 'rosters', 'name', 'id', 'slack_channel', 'email',
+    expected_set = {'users', 'admins', 'services', 'rosters', 'name', 'id', 'slack_channel', 'slack_channel_notifications', 'email',
         'scheduling_timezone', 'iris_plan', 'iris_enabled', 'override_phone_number'}
     assert expected_set == set(team.keys())
 
@@ -67,7 +67,7 @@ def test_api_v0_get_team(team, role, roster, schedule):
     assert re.status_code == 200
     team = re.json()
     assert isinstance(team, dict)
-    expected_set = {'users', 'admins', 'services', 'name', 'id', 'slack_channel', 'email',
+    expected_set = {'users', 'admins', 'services', 'name', 'id', 'slack_channel', 'slack_channel_notifications', 'email',
                     'scheduling_timezone', 'iris_plan', 'iris_enabled', 'override_phone_number'}
     assert expected_set == set(team.keys())
 
@@ -88,6 +88,8 @@ def test_api_v0_update_team(team):
     new_team_name = "new-moninfra-update"
     email = 'abc@gmail.com'
     slack = '#slack'
+    slack_notifications = '#slack-alerts'
+
     override_num = '1234'
 
     # setup DB state
@@ -101,6 +103,7 @@ def test_api_v0_update_team(team):
     re = requests.put(api_v0('teams/'+team_name), json={'name': new_team_name,
                                                         'email': email,
                                                         'slack_channel': slack,
+                                                        'slack_channel_notificationse': slack_notifications,
                                                         'override_phone_number': override_num})
     assert re.status_code == 200
     team.mark_for_cleaning(new_team_name)
@@ -112,6 +115,7 @@ def test_api_v0_update_team(team):
     data = re.json()
     assert data['email'] == email
     assert data['slack_channel'] == slack
+    assert data['slack_channel_notifications'] == slack_notifications
     assert data['override_phone_number'] == override_num
 
 

--- a/e2e/test_teams.py
+++ b/e2e/test_teams.py
@@ -87,8 +87,8 @@ def test_api_v0_update_team(team):
     team_name = team.create()
     new_team_name = "new-moninfra-update"
     email = 'abc@gmail.com'
-    slack = 'slack'
-    slack_notifications = 'slack-alerts'
+    slack = '#slack'
+    slack_notifications = '#slack-alerts'
 
     override_num = '1234'
 

--- a/src/oncall/api/v0/team.py
+++ b/src/oncall/api/v0/team.py
@@ -147,8 +147,9 @@ def on_get(req, resp, team):
 
     connection = db.connect()
     cursor = connection.cursor(db.DictCursor)
-    cursor.execute('SELECT `id`, `name`, `email`, `slack_channel`, `slack_channel_notifications`, `scheduling_timezone`, `iris_plan`, `iris_enabled`, `override_phone_number` '
-                   'FROM `team` WHERE `name`=%s AND `active` = %s', (team, active))
+    cursor.execute('''SELECT `id`, `name`, `email`, `slack_channel`, `slack_channel_notifications`,
+                             `scheduling_timezone`, `iris_plan`, `iris_enabled`, `override_phone_number`
+                      FROM `team` WHERE `name`=%s AND `active` = %s''', (team, active))
     results = cursor.fetchall()
     if not results:
         raise HTTPNotFound()

--- a/src/oncall/api/v0/team.py
+++ b/src/oncall/api/v0/team.py
@@ -147,7 +147,7 @@ def on_get(req, resp, team):
 
     connection = db.connect()
     cursor = connection.cursor(db.DictCursor)
-    cursor.execute('SELECT `id`, `name`, `email`, `slack_channel`, `scheduling_timezone`, `iris_plan`, `iris_enabled`, `override_phone_number` '
+    cursor.execute('SELECT `id`, `name`, `email`, `slack_channel`, `slack_channel_notifications`, `scheduling_timezone`, `iris_plan`, `iris_enabled`, `override_phone_number` '
                    'FROM `team` WHERE `name`=%s AND `active` = %s', (team, active))
     results = cursor.fetchall()
     if not results:

--- a/src/oncall/api/v0/team.py
+++ b/src/oncall/api/v0/team.py
@@ -13,9 +13,9 @@ from ...auth import login_required, check_team_auth
 from ...utils import load_json_body, invalid_char_reg, create_audit
 from ...constants import TEAM_DELETED, TEAM_EDITED
 
-
-cols = set(['name', 'slack_channel', 'email', 'scheduling_timezone', 'iris_plan', 'iris_enabled',
-            'override_phone_number'])
+# Columns which may be modified
+cols = set(['name', 'slack_channel', 'slack_channel_notifications', 'email', 'scheduling_timezone',
+            'iris_plan', 'iris_enabled', 'override_phone_number'])
 
 
 def populate_team_users(cursor, team_dict):

--- a/src/oncall/api/v0/teams.py
+++ b/src/oncall/api/v0/teams.py
@@ -128,7 +128,7 @@ def on_post(req, resp):
             "scheduling_timezone": "US/Pacific",
             "email": "team-foo@example.com",
             "slack_channel": "#team-foo",
-            "slack_channel": "#team-foo-alerts",
+            "slack_channel_notifications": "#team-foo-alerts",
         }
 
     **Example response:**

--- a/src/oncall/api/v0/teams.py
+++ b/src/oncall/api/v0/teams.py
@@ -182,8 +182,8 @@ def on_post(req, resp):
     connection = db.connect()
     cursor = connection.cursor()
     try:
-        cursor.execute('''INSERT INTO `team` (`name`, `slack_channel`, `slack_channel_notifications`, `email`, `scheduling_timezone`, `iris_plan`, `iris_enabled`,
-                                              `override_phone_number`)
+        cursor.execute('''INSERT INTO `team` (`name`, `slack_channel`, `slack_channel_notifications`, `email`, `scheduling_timezone`,
+                                              `iris_plan`, `iris_enabled`, `override_phone_number`)
                           VALUES (%s, %s, %s, %s, %s, %s, %s, %s)''',
                        (team_name, slack, slack_notifications, email, scheduling_timezone, iris_plan, iris_enabled, override_number))
 

--- a/src/oncall/api/v0/teams.py
+++ b/src/oncall/api/v0/teams.py
@@ -184,7 +184,7 @@ def on_post(req, resp):
     try:
         cursor.execute('''INSERT INTO `team` (`name`, `slack_channel`, `slack_channel_notifications`, `email`, `scheduling_timezone`, `iris_plan`, `iris_enabled`,
                                               `override_phone_number`)
-                          VALUES (%s, %s, %s, %s, %s, %s, %s)''',
+                          VALUES (%s, %s, %s, %s, %s, %s, %s, %s)''',
                        (team_name, slack, slack_notifications, email, scheduling_timezone, iris_plan, iris_enabled, override_number))
 
         team_id = cursor.lastrowid

--- a/src/oncall/api/v0/teams.py
+++ b/src/oncall/api/v0/teams.py
@@ -108,6 +108,7 @@ def on_post(req, resp):
     - name: the team's name. Teams must have unique names.
     - email: email address for the team.
     - slack_channel: slack channel for the team. Must start with '#'
+    - slack_channel_notifications: slack channel for notifications. Must start with '#'
     - iris_plan: Iris escalation plan that incidents created from the Oncall UI will follow.
 
     If iris plan integration is not activated, this attribute can still be set, but its
@@ -127,6 +128,7 @@ def on_post(req, resp):
             "scheduling_timezone": "US/Pacific",
             "email": "team-foo@example.com",
             "slack_channel": "#team-foo",
+            "slack_channel": "#team-foo-alerts",
         }
 
     **Example response:**
@@ -160,6 +162,10 @@ def on_post(req, resp):
     if slack and slack[0] != '#':
         raise HTTPBadRequest('invalid slack channel',
                              'slack channel name needs to start with #')
+    slack_notifications = data.get('slack_channel_notifications')
+    if slack_notifications and slack_notifications[0] != '#':
+        raise HTTPBadRequest('invalid slack notifications channel',
+                             'slack channel notifications name needs to start with #')
     email = data.get('email')
     iris_plan = data.get('iris_plan')
     iris_enabled = data.get('iris_enabled', False)
@@ -176,10 +182,10 @@ def on_post(req, resp):
     connection = db.connect()
     cursor = connection.cursor()
     try:
-        cursor.execute('''INSERT INTO `team` (`name`, `slack_channel`, `email`, `scheduling_timezone`, `iris_plan`, `iris_enabled`,
+        cursor.execute('''INSERT INTO `team` (`name`, `slack_channel`, `slack_channel_notifications`, `email`, `scheduling_timezone`, `iris_plan`, `iris_enabled`,
                                               `override_phone_number`)
                           VALUES (%s, %s, %s, %s, %s, %s, %s)''',
-                       (team_name, slack, email, scheduling_timezone, iris_plan, iris_enabled, override_number))
+                       (team_name, slack, slack_notifications, email, scheduling_timezone, iris_plan, iris_enabled, override_number))
 
         team_id = cursor.lastrowid
         query = '''

--- a/src/oncall/ui/static/js/oncall.js
+++ b/src/oncall/ui/static/js/oncall.js
@@ -801,6 +801,7 @@ var oncall = {
           name = $form.find('#team-name').val(),
           email = $form.find('#team-email').val(),
           slack = $form.find('#team-slack').val(),
+          slack_notifications = $form.find('#team-slack-notifications').val(),
           timezone = $form.find('#team-timezone').val(),
           $irisEnabled = $form.find('#team-iris-enabled'),
           model = {};
@@ -839,6 +840,7 @@ var oncall = {
           name = $form.find('#team-name').val(),
           email = $form.find('#team-email').val(),
           slack = $form.find('#team-slack').val(),
+          slack_notifications = $form.find('#team-slack-notifications').val(),
           timezone = $form.find('#team-timezone').val(),
           overrideNumber = $form.find('#team-override-phone').val(),
           irisPlan = $form.find('#team-irisplan').val(),
@@ -865,6 +867,7 @@ var oncall = {
               name: name,
               email: email,
               slack_channel: slack,
+              slack_channel_notifications: slack_notifications,
               scheduling_timezone: timezone,
               override_phone_number: overrideNumber,
               iris_plan: irisPlan,
@@ -3087,6 +3090,7 @@ var oncall = {
           $teamName = $modalForm.find('#team-name'),
           $teamEmail = $modalForm.find('#team-email'),
           $teamSlack = $modalForm.find('#team-slack'),
+          $teamSlackNotifications = $modalForm.find('#team-slack-notifications'),
           $teamTimezone = $modalForm.find('#team-timezone'),
           $teamNumber = $modalForm.find('#team-override-phone'),
           $teamIrisPlan = $modalForm.find('#team-irisplan'),
@@ -3102,6 +3106,7 @@ var oncall = {
         $teamName.val($btn.attr('data-modal-name'));
         $teamEmail.val($btn.attr('data-modal-email'));
         $teamSlack.val($btn.attr('data-modal-slack'));
+        $teamSlackNotifications.val($btn.attr('data-modal-slack-notifications'));
         $teamNumber.val($btn.attr('data-modal-override-phone'));
         $teamIrisPlan.val($btn.attr('data-modal-irisplan'));
         $teamIrisEnabled.prop('checked', $btn.attr('data-modal-iris-enabled') === '1');

--- a/src/oncall/ui/templates/base.html
+++ b/src/oncall/ui/templates/base.html
@@ -132,6 +132,9 @@
               <label for="team-slack"> Team Slack: </label> <input type="text" name="slack_channel" id="team-slack" class="form-control" placeholder="#SlackChannel" />
             </p>
             <p>
+              <label for="team-slack-notifications"> Notifications Slack: </label> <input type="text" name="slack_channel_notifications" id="team-slack-notifications" class="form-control" placeholder="#SlackChannel-Alerts" />
+            </p>
+            <p>
               <label for="team-timezone"> Team Scheduling Timezone: </label>
               <select name="scheduling_timezone" id="team-timezone" class="form-control team-timezone">
                 {%  for timezone in timezones %}

--- a/src/oncall/ui/templates/index.html
+++ b/src/oncall/ui/templates/index.html
@@ -303,7 +303,7 @@
           <h3>
             {{name}}
             <span class="edit-team-name">
-              <i class="svg-icon svg-icon-pencil" data-toggle="modal" data-target="#team-edit-modal" data-modal-action="oncall.team.updateTeamName" data-modal-title="Update Team Info" data-modal-name="{{#if name}}{{name}}{{else}}{{@key}}{{/if}}" data-modal-email="{{email}}" data-modal-slack="{{slack_channel}}" data-modal-timezone="{{scheduling_timezone}}" data-modal-irisplan="{{iris_plan}}" data-modal-iris-enabled="{{iris_enabled}}" data-modal-override-phone="{{override_phone_number}}" data-admin-action="true">
+              <i class="svg-icon svg-icon-pencil" data-toggle="modal" data-target="#team-edit-modal" data-modal-action="oncall.team.updateTeamName" data-modal-title="Update Team Info" data-modal-name="{{#if name}}{{name}}{{else}}{{@key}}{{/if}}" data-modal-email="{{email}}" data-modal-slack="{{slack_channel}}" data-modal-slack-notifications="{{slack_channel_notifications}}" data-modal-timezone="{{scheduling_timezone}}" data-modal-irisplan="{{iris_plan}}" data-modal-iris-enabled="{{iris_enabled}}" data-modal-override-phone="{{override_phone_number}}" data-admin-action="true">
                 <svg xmlns="http://www.w3.org/2000/svg" width="16px" height="16px" viewBox="0 0 8 8" style="fill: currentColor">
                   <path d="M6 0l-1 1 2 2 1-1-2-2zm-2 2l-4 4v2h2l4-4-2-2z" />
                 </svg>
@@ -326,6 +326,11 @@
             <a href="https://{% endraw %}{{slack_instance}}{% raw %}.slack.com/messages/{{stripHash slack_channel}}/" target="_blank">{{slack_channel}}</a>
           {{else}}
             No Slack Channel
+          {{/if}}
+          {{#if slack_channel_notifications}}
+            <a href="https://{% endraw %}{{slack_instance}}{% raw %}.slack.com/messages/{{stripHash slack_channel_notifications}}/" target="_blank">{{slack_channel_notifications}}</a>
+          {{else}}
+            No Slack Notifications Channel
           {{/if}}
         </h4>
         {% endraw %} {% endif %} {% raw %}


### PR DESCRIPTION
Often you need to track a different slack channel for Team Chat vs Team Notifications -- this change adds a column to track that and adds api and UI support.