### PR TITLE
adjust team info subheader

### DIFF
--- a/src/oncall/ui/static/css/oncall.css
+++ b/src/oncall/ui/static/css/oncall.css
@@ -289,7 +289,7 @@ nav.subnav li.active {
 
 .subheader {
   padding: 20px;
-  height: 100px;
+  height: 110px;
   color: #fff;
 }
 

--- a/src/oncall/ui/templates/index.html
+++ b/src/oncall/ui/templates/index.html
@@ -327,10 +327,10 @@
           {{else}}
             No Slack Channel
           {{/if}}
+        </h4>
+        <h4>
           {{#if slack_channel_notifications}}
             <a href="https://{% endraw %}{{slack_instance}}{% raw %}.slack.com/messages/{{stripHash slack_channel_notifications}}/" target="_blank">{{slack_channel_notifications}}</a>
-          {{else}}
-            No Slack Notifications Channel
           {{/if}}
         </h4>
         {% endraw %} {% endif %} {% raw %}


### PR DESCRIPTION
- add space between slack channels
- display nothing if team notification slack channel isn't defined