### PR TITLE
Helm3 chart 

### DIFF
--- a/ops/charts/oncall/.gitignore
+++ b/ops/charts/oncall/.gitignore
@@ -1,0 +1,2 @@
+charts
+*.tgz

--- a/ops/charts/oncall/Chart.yaml
+++ b/ops/charts/oncall/Chart.yaml
@@ -1,0 +1,13 @@
+name: oncall
+version: 0.0.1
+description: Calendar tool designed for scheduling and managing on-call shifts
+keywords:
+  - calendar
+  - schedule
+  - shifts management
+home: https://oncall.tools
+sources:
+  - https://github.com/linkedin/oncall
+engine: gotpl
+icon: https://raw.githubusercontent.com/linkedin/oncall/master/src/oncall/ui/static/images/favicon.png
+appVersion: 0.0.14

--- a/ops/charts/oncall/README.md
+++ b/ops/charts/oncall/README.md
@@ -1,0 +1,10 @@
+Oncall chart
+==========
+
+Usage
+-----
+
+```
+helm3 dep update
+helm3 install oncall . -n test
+```

--- a/ops/charts/oncall/config/config.yaml
+++ b/ops/charts/oncall/config/config.yaml
@@ -1,0 +1,234 @@
+#######################
+### Oncall-api settings
+#######################
+server:
+  host: 0.0.0.0
+  port: {{ .Values.oncallService.internalPort }}
+oncall_host: http://localhost:{{ .Values.oncallService.internalPort }}
+metrics: dummy
+db:
+  conn:
+    kwargs:
+      scheme: mysql+pymysql
+      user: root
+      password: {{ .Values.mysql.auth.rootPassword | quote }}
+      host: {{ include "mysql.fullname" . }}
+      port: 3306
+      database: oncall
+      charset: utf8
+      echo: True
+    str: "%(scheme)s://%(user)s:%(password)s@%(host)s:%(port)s/%(database)s?charset=%(charset)s"
+  kwargs:
+    pool_recycle: 3600
+healthcheck_path: /tmp/status
+
+# Keys for encrypting/signing session cookies.
+# Change to random long values in production.
+session:
+  encrypt_key: 'abc'
+  sign_key: '123'
+
+# Debug mode toggle. Disable in production.
+# Debug mode disables authentication, allows access to debug-only API endpoints
+# (used for testing), allows HTTP access, and removes some security headers
+# from responses.
+debug: True
+
+## To run Oncall without https, set this value to True
+## WARNING: use this only for debugging purposes, to avoid sending
+## usernames and passwords in plain text.
+#allow_http: False
+
+# Pluggable authentication module configuration.
+# Additional auth modules can be added by implementing the Authenticator
+# class, with two required methods: __init__(self, config) and
+# authenticate(self, username, password)
+auth:
+  debug: True
+  module: 'oncall.auth.modules.debug'  # Auth module where Authenticator is implemented
+
+# Example configuration for LDAP-based auth
+#   module: 'oncall.auth.modules.ldap_example'
+#   module: 'oncall.auth.modules.ldap_import' # for automatically import user at first connexion
+#   ldap_url: 'ldaps://example.com'
+#   ldap_user_suffix: '@example.biz'
+#   ldap_cert_path: '/etc/ldap_cert.pem'
+#   ldap_bind_user: 'cn=binduser,ou=services,dc=company,dc=org'
+#   ldap_bind_password: 'abc123'
+#   ldap_base_dn: 'ou=accounts,dc=company,dc=org'
+#   ldap_search_filter: '(uid=%s)'
+# options used by the ldap_import module.
+#   import_user: True
+#   attrs:
+#     username: 'uid'
+#     full_name: 'displayName'
+#     email: 'mail'
+#     mobile: 'mobile'
+#     sms: 'phone'
+#     slack: 'uid'
+
+############################
+### Oncall-notifier settings
+############################
+notifier:
+  # Skip sending messages, log instead
+  skipsend: True
+
+# Reminder notification settings
+notifications:
+  # The notifier will send reminders for events with these roles
+  default_roles:
+    - "primary"
+    - "secondary"
+    - "shadow"
+    - "manager"
+  # Reminders will be sent $x seconds before events start, for $x in this list
+  default_times:
+    - 86400
+    - 604800
+  # Reminders are sent using these modes of contact
+  default_modes:
+    - "email"
+    # - "teams_messenger"
+# Reminder task settings
+reminder:
+  activated: True
+  polling_interval: 360  # In seconds, the reminder will poll DB for events every $n seconds
+  default_timezone: 'US/Pacific'  # Dates/times in the reminders are formatted in this timezone
+
+# User validator checks that people scheduled for on-call events have defined phone numbers
+user_validator:
+  activated: True
+  subject: 'Warning: Missing phone number in Oncall'
+  body: 'You are scheduled for an on-call shift in the future, but have no phone number recorded. Please update your information in Oncall.'
+
+# Reminders sent using these messengers
+messengers:
+#   - type: teams_messenger
+#     webhook: "channel_webhook_url"
+#
+#   - type: rocketchat_messenger
+#     user: username
+#     password: abc123
+#     refresh: 60000
+#     api_host: https://example.rocket.chat
+#
+#  - type: iris_messenger
+#    application: oncall
+#    iris_api_key: magic
+#    api_host: http://localhost:16649
+
+  - type: dummy
+    application: oncall
+    iris_api_key: magic
+
+############################
+### Oncall frontend settings
+############################
+supported_timezones:
+  - 'US/Pacific'
+  - 'US/Eastern'
+  - 'US/Central'
+  - 'US/Mountain'
+  - 'US/Alaska'
+  - 'US/Hawaii'
+  - 'Asia/Kolkata'
+  - 'Asia/Shanghai'
+  - 'UTC'
+
+index_content_setting:
+  # Page footer contents
+  #footer: |
+  #  <ul>
+  #    <li>Oncall © LinkedIn 2020</li>
+  #    <li>Feedback</li>
+  #    <li><a href="http://oncall.tools" target="_blank">About</a></li>
+  #  </ul>
+  # Note displayed when a user has no phone number
+  missing_number_note: 'No number'
+header_color: '#3a3a3a'
+
+# The base url for the public oncall calendar. This url has to open to the public internet for most web calendar subscriptions to work.
+# The public calendar url will be formatted as follows: "{public_calendar_base_url}/{ical_key}".
+# Replace localhost with the hostname of the oncall or iris-relay instance.
+public_calendar_base_url: 'http://localhost:{{ .Values.oncallService.internalPort }}/api/v0/ical'
+# Additional message you want to put here, could be a link to the FAQ
+public_calendar_additional_message: 'Link to FAQ'
+
+# Integration with Iris, allowing for escalation from Oncall
+iris_plan_integration:
+  activated: True
+  # Iris app and key settings
+  app: oncall
+  api_key: magic
+  api_host: http://localhost:16649
+  # API url to get a list of Oncall-compatible plans
+  # This will be /v0/applications/$app_name/plans
+  plan_url: '/v0/applications/oncall/plans'
+  # Plan to follow with urgent escalations; must be a dynamic plan
+  urgent_plan:
+    name: 'Oncall test'
+    # In the Iris plan, dynamic target $n will map to dynamic_targets[$n].
+    # For example, here, Iris target 0 will be the oncall-primary of the
+    # team, target 1 will be the team, and target 2 will be the manager
+    dynamic_targets:
+      - role: 'oncall-primary'
+      - role: 'team'
+      - role: 'manager'
+  # Similar to above, but for medium teams.
+  medium_plan:
+    name: 'Oncall test'
+    dynamic_targets:
+      - role: 'oncall-primary'
+      - role: 'team'
+      - role: 'manager'
+# CORS settings
+# allow_origins_list:
+#   - http://www.example.com
+
+# Configures whether Slack settings will appear in the frontend
+slack_instance: foobar
+
+# Setting to determine whether the Oncall API/frontend is available unauthenticated.
+# Set to True to force login splash page and authentication on API calls and False to allow read
+# APIs without authentication
+require_auth: False
+
+###########################
+### Oncall bonus management
+###########################
+# add_bonus_events_api: True
+# bonus_url: 'https://ONCALL_BONUS_TEAMS_ENDPOINT'
+# bonus_whitelist:
+#      - 'team_foo'
+# bonus_blacklist:
+#      - 'team_bar'
+#      - 'team_baz'
+
+##########################
+### Oncall user management
+##########################
+
+# # Configure which user_sync module is being used
+# user_sync:
+#   module: 'oncall.user_sync.ldap_sync'
+#
+# # User management by syncing from Slack
+# slack:
+#   oauth_access_token: 'foo'
+#
+# # User management by syncing from LDAP
+# ldap_sync:
+#   url: 'ldaps://example.com'
+#   base: 'ou=Staff Users,dc=multiforest,dc=biz'
+#   user: 'CN=example,DC=multiforest,DC=biz'
+#   password: 'password'
+#   cert_path: '/etc/ldap_cert.pem'
+#   query: '(&(objectClass=userProxy)(employeeId=*))'
+#   # Map of Oncall user information to LDAP attribute
+#   attrs:
+#     username: 'sAMAccountName'
+#     full_name: 'displayName'
+#     mail: 'mail'
+#     mobile: 'mobile'
+#   image_url: 'https://image.example.com/api/%s/picture'

--- a/ops/charts/oncall/requirements.lock
+++ b/ops/charts/oncall/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: mysql
+  repository: https://charts.bitnami.com/bitnami
+  version: 8.0.0
+digest: sha256:290300d7be7bcc2a1d5d9da973d66c21167a56e924b7140d376a06f88f74fd8a
+generated: "2020-12-03T11:55:11.445613061+01:00"

--- a/ops/charts/oncall/requirements.yaml
+++ b/ops/charts/oncall/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+  - name: mysql
+    version: 8.0.0
+    repository: https://charts.bitnami.com/bitnami

--- a/ops/charts/oncall/templates/NOTES.txt
+++ b/ops/charts/oncall/templates/NOTES.txt
@@ -1,0 +1,17 @@
+## For internal access
+
+The Oncall service can be accessed via port {{ .Values.oncallService.externalPort }} on the following DNS names from within your cluster:
+
+    `oncall` or `oncall.{{ .Release.Namespace }}.svc.cluster.local`
+
+
+## For external access
+
+Oncall service is configured to use NodePort type, you can use the following
+command to get the external port for the service:
+
+    kubectl describe services oncall
+
+For external IP, use:
+
+    kubectl cluster-info

--- a/ops/charts/oncall/templates/_helpers.tpl
+++ b/ops/charts/oncall/templates/_helpers.tpl
@@ -1,0 +1,23 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "mysql.fullname" -}}
+{{- printf "%s-%s" .Release.Name "mysql" | trunc 24 -}}
+{{- end -}}

--- a/ops/charts/oncall/templates/config-map.yaml
+++ b/ops/charts/oncall/templates/config-map.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: oncall-config
+data:
+  config.yaml: |-
+{{ tpl (.Files.Get "config/config.yaml") . | nindent 4 }}

--- a/ops/charts/oncall/templates/deployment.yaml
+++ b/ops/charts/oncall/templates/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    oncall-component: api
+    oncall-component: web
+    oncall-component: sender
+    oncall-version: {{ .Chart.AppVersion }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ template "fullname" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+    spec:
+      containers:
+        - name: oncall
+          image: {{ .Values.imageRegistry }}/oncall:{{.Values.dockerTag}}
+          imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+          ports:
+            - containerPort: {{ .Values.oncallService.internalPort }}
+          env:
+            {{- if not .Values.oncallService.dbInitialized }}
+            - name: DOCKER_DB_BOOTSTRAP
+              value: '1'
+            {{- end }}
+          volumeMounts:
+            - name: oncall-volume
+              mountPath: /home/oncall/config
+              readOnly: true
+      volumes:
+        - name: oncall-volume
+          configMap:
+            name: oncall-config

--- a/ops/charts/oncall/templates/service.yaml
+++ b/ops/charts/oncall/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: oncall
+  labels:
+    oncall-component: api
+    oncall-component: web
+    oncall-version: {{ .Chart.AppVersion }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+spec:
+  ports:
+    - name: oncall
+      port: {{ .Values.oncallService.externalPort }}
+      targetPort: {{ .Values.oncallService.internalPort }}
+      protocol: TCP
+  selector:
+    app: {{ template "fullname" . }}
+  type: NodePort

--- a/ops/charts/oncall/values.yaml
+++ b/ops/charts/oncall/values.yaml
@@ -1,0 +1,13 @@
+imageRegistry: "quay.io/iris"
+dockerTag: "latest"
+pullPolicy: "alwaysPull"
+replicaCount: 1
+
+oncallService:
+  externalPort: 80
+  internalPort: 8080
+  dbInitialized: false
+
+mysql:
+  auth:
+    rootPassword: "1234"


### PR DESCRIPTION
Helm3 chart for oncall application. 

Latest image available at official Docker repository for the oncall is 3 years old (https://quay.io/repository/iris/oncall?tab=tags), so it won't work with up to date mysql used in this code: 
```
ERROR 2026 (HY000): SSL connection error: unknown error number
```
As a permanent fix updated image should be pushed to quay.io (or Docker Hub; it took me 5 minutes to create account and set up automatic build), as a quick fix for anyone interested in using chart I suggest:
- building oncall image from source and configuring image registry
- or using my image from Docker Hub, to do this change line 24 in file `ops/charts/oncall/templates/deployment.yaml` to:
```
        image: "lukdz/oncall:latest"`
```

Code is based on: https://github.com/linkedin/iris/tree/master/ops/charts/iris
I would like to give credit for great tutorial: https://banzaicloud.com/blog/creating-helm-charts-part-2/