### PR TITLE
Helm3 chart added ingress and auth

### DIFF
--- a/ops/charts/oncall/config/config.yaml
+++ b/ops/charts/oncall/config/config.yaml
@@ -44,28 +44,67 @@ debug: True
 # class, with two required methods: __init__(self, config) and
 # authenticate(self, username, password)
 auth:
-  debug: True
+  debug: {{ .Values.oncallService.auth.debug | toString | title }}
+  {{- if .Values.oncallService.auth.modules.debug }}
   module: 'oncall.auth.modules.debug'  # Auth module where Authenticator is implemented
+  {{- end }}
 
 # Example configuration for LDAP-based auth
-#   module: 'oncall.auth.modules.ldap_example'
-#   module: 'oncall.auth.modules.ldap_import' # for automatically import user at first connexion
-#   ldap_url: 'ldaps://example.com'
-#   ldap_user_suffix: '@example.biz'
-#   ldap_cert_path: '/etc/ldap_cert.pem'
-#   ldap_bind_user: 'cn=binduser,ou=services,dc=company,dc=org'
-#   ldap_bind_password: 'abc123'
-#   ldap_base_dn: 'ou=accounts,dc=company,dc=org'
-#   ldap_search_filter: '(uid=%s)'
+  {{- if .Values.oncallService.auth.modules.ldap_example }}
+  module: 'oncall.auth.modules.ldap_example'
+  {{- end }}
+  {{- if .Values.oncallService.auth.modules.ldap_import }}
+  module: 'oncall.auth.modules.ldap_import' # for automatically import user at first connexion
+  {{- end }}
+  {{- if .Values.oncallService.auth.ldap_url }}
+  ldap_url: {{ .Values.oncallService.auth.ldap_url | squote }}
+  {{- end }}
+  {{- if .Values.oncallService.auth.ldap_user_suffix }}
+  ldap_user_suffix: {{ .Values.oncallService.auth.ldap_user_suffix | squote }}
+  {{- end }}
+  {{- if .Values.oncallService.auth.ldap_cert_path }}
+  ldap_cert_path: {{ .Values.oncallService.auth.ldap_cert_path | squote }}
+  {{- end }}
+  {{- if .Values.oncallService.auth.ldap_bind_user }}
+  ldap_bind_user: {{ .Values.oncallService.auth.ldap_bind_user | squote }}
+  {{- end }}
+  {{- if .Values.oncallService.auth.ldap_bind_password }}
+  ldap_bind_password: {{ .Values.oncallService.auth.ldap_bind_password | squote }}
+  {{- end }}
+  {{- if .Values.oncallService.auth.ldap_base_dn }}
+  ldap_base_dn: {{ .Values.oncallService.auth.ldap_base_dn | squote }}
+  {{- end }}
+  {{- if .Values.oncallService.auth.ldap_search_filter }}
+  ldap_search_filter: {{ .Values.oncallService.auth.ldap_search_filter | squote }}
+  {{- end }}
 # options used by the ldap_import module.
-#   import_user: True
-#   attrs:
-#     username: 'uid'
-#     full_name: 'displayName'
-#     email: 'mail'
-#     mobile: 'mobile'
-#     sms: 'phone'
-#     slack: 'uid'
+  {{- if kindIs "bool" .Values.oncallService.auth.import_user }}
+  import_user: {{ .Values.oncallService.auth.import_user | toString | title }}
+  {{- end }}
+  {{- if .Values.oncallService.auth.attrs }}
+  attrs:
+    {{- if .Values.oncallService.auth.attrs.username }}
+    username: {{ .Values.oncallService.auth.attrs.username | squote }}
+    {{- end }}
+    {{- if .Values.oncallService.auth.attrs.full_name }}
+    full_name: {{ .Values.oncallService.auth.attrs.full_name | squote }}
+    {{- end }}
+    {{- if .Values.oncallService.auth.attrs.email }}
+    email: {{ .Values.oncallService.auth.attrs.email | squote }}
+    {{- end }}
+    {{- if .Values.oncallService.auth.attrs.call }}
+    call: {{ .Values.oncallService.auth.attrs.call | squote }}
+    {{- end }}
+    {{- if .Values.oncallService.auth.attrs.sms }}
+    sms: {{ .Values.oncallService.auth.attrs.sms | squote }}
+    {{- end }}
+    {{- if .Values.oncallService.auth.attrs.slack }}
+    slack: {{ .Values.oncallService.auth.attrs.slack | squote }}
+    {{- end }}
+    {{- if .Values.oncallService.auth.attrs.name }}
+    name: {{ .Values.oncallService.auth.attrs.name | squote }}
+    {{- end }}
+  {{- end }}
 
 ############################
 ### Oncall-notifier settings
@@ -94,7 +133,7 @@ notifications:
 reminder:
   activated: True
   polling_interval: 360  # In seconds, the reminder will poll DB for events every $n seconds
-  default_timezone: 'US/Pacific'  # Dates/times in the reminders are formatted in this timezone
+  default_timezone: {{ .Values.oncallService.timezone | squote }}  # Dates/times in the reminders are formatted in this timezone
 
 # User validator checks that people scheduled for on-call events have defined phone numbers
 user_validator:
@@ -126,7 +165,9 @@ messengers:
 ### Oncall frontend settings
 ############################
 supported_timezones:
-  - 'US/Pacific'
+  {{- if .Values.oncallService.timezone }}
+  - {{ .Values.oncallService.timezone | squote }}
+  {{- end }}
   - 'US/Eastern'
   - 'US/Central'
   - 'US/Mountain'
@@ -140,7 +181,7 @@ index_content_setting:
   # Page footer contents
   #footer: |
   #  <ul>
-  #    <li>Oncall © LinkedIn 2020</li>
+  #    <li>Oncall (c) LinkedIn 2020</li>
   #    <li>Feedback</li>
   #    <li><a href="http://oncall.tools" target="_blank">About</a></li>
   #  </ul>

--- a/ops/charts/oncall/templates/deployment.yaml
+++ b/ops/charts/oncall/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: oncall
-          image: {{ .Values.imageRegistry }}/oncall:{{.Values.dockerTag}}
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
           ports:
             - containerPort: {{ .Values.oncallService.internalPort }}

--- a/ops/charts/oncall/templates/ingress.yaml
+++ b/ops/charts/oncall/templates/ingress.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
+    {{- if .Values.ingress.certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
+  name: {{ template "fullname" . }}
+spec:
+  rules:
+    {{- if .Values.ingress.hostname }}
+    - host: {{ .Values.ingress.hostname }}
+      http:
+        paths:
+        - backend:
+            serviceName: {{ template "name" . }}
+            servicePort: {{ .Values.oncallService.externalPort }}
+          path: /
+    {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+  - hosts:
+    - {{ .Values.ingress.hostname }}
+    secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
+  {{- end }}
+{{- end }}

--- a/ops/charts/oncall/templates/service.yaml
+++ b/ops/charts/oncall/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: oncall
+  name: {{ template "name" . }}
   labels:
     oncall-component: api
     oncall-component: web
@@ -9,7 +9,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
 spec:
   ports:
-    - name: oncall
+    - name: {{ template "name" . }}
       port: {{ .Values.oncallService.externalPort }}
       targetPort: {{ .Values.oncallService.internalPort }}
       protocol: TCP

--- a/ops/charts/oncall/values.yaml
+++ b/ops/charts/oncall/values.yaml
@@ -1,13 +1,31 @@
-imageRegistry: "quay.io/iris"
-dockerTag: "latest"
+image:
+  repository: "quay.io/iris"
+  tag: "latest"
 pullPolicy: "alwaysPull"
 replicaCount: 1
 
 oncallService:
   externalPort: 80
   internalPort: 8080
-  dbInitialized: false
+  dbInitialized: False
+  auth:
+    debug: True
+    modules:
+      debug: True
+      ldap_example: False
+      ldap_import: False
+  timezone: 'US/Pacific'
+
+ingress:
+  enabled: False
+  class: nginx
+  certManager: True
+  hostname: "test.com"
+  tls: True
 
 mysql:
   auth:
     rootPassword: "1234"
+  primary:
+    persistence:
+      size: 1Gi


### PR DESCRIPTION
### Description
Helm3 chart:
- updated with automatic authentication configuration from chart file `values.yaml`
- added `ingress.yaml`

From chart `README.md` removed namespace option.

### For testing:
Latest image available at official Docker repository for the oncall is 3 years old (https://quay.io/repository/iris/oncall?tab=tags), so it won't work with up to date mysql used in this code: 
```
ERROR 2026 (HY000): SSL connection error: unknown error number
```
As a permanent fix updated image should be pushed to quay.io (or Docker Hub; it took me 5 minutes to create account and set up automatic build), as a quick fix for anyone interested in using chart I suggest:
- build oncall image from source and configuring image registry
- or use my image from Docker Hub, to do this change line 1 in file `ops/charts/oncall/values.yaml` to:
```
imageRegistry: "lukdz"
```