### PR TITLE
chart v3

### DIFF
--- a/ops/charts/oncall/Chart.yaml
+++ b/ops/charts/oncall/Chart.yaml
@@ -1,6 +1,8 @@
+apiVersion: v2
 name: oncall
-version: 0.0.1
+version: 0.0.2
 description: Calendar tool designed for scheduling and managing on-call shifts
+type: application
 keywords:
   - calendar
   - schedule
@@ -10,4 +12,8 @@ sources:
   - https://github.com/linkedin/oncall
 engine: gotpl
 icon: https://raw.githubusercontent.com/linkedin/oncall/master/src/oncall/ui/static/images/favicon.png
-appVersion: 0.0.14
+appVersion: 1.2.4
+dependencies:
+  - name: mysql
+    version: 8.0.0
+    repository: https://charts.bitnami.com/bitnami

--- a/ops/charts/oncall/README.md
+++ b/ops/charts/oncall/README.md
@@ -1,10 +1,60 @@
-Oncall chart
-==========
+# Oncall chart
 
-Usage
------
+Oncall is a calendar tool designed for scheduling and managing on-call shifts. It is a standalone application that serves as source of truth for dynamic ownership information as well as contact info.
 
+
+## Installing the Chart
+To install the chart with the release name `oncall-release`:
 ```
+cd ops/charts/oncall
 helm3 dep update
-helm3 install oncall . -n test
+helm3 install oncall-release .
 ```
+
+## Parameters
+
+### Port parameters
+
+| Parameter          | Description              | Default |
+|--------------------|--------------------------|---------|
+| `port.external`    | External port for OnCall | `80`    |
+| `port.internal`    | Internal port for OnCall | `8080`  |
+
+### Config parameters
+
+| Parameter                             | Description                                    | Default      |
+|---------------------------------------|------------------------------------------------|--------------|
+| `config.auth.debug`                   | Debug mode toggle, disable in production       | `true`       |
+| `config.auth.module`                  | Auth module where Authenticator is implemented | `debug`      |
+| `config.auth.ldap.ldap_url`           | LDAP url                                       | `nil`        |
+| `config.auth.ldap.ldap_user_suffix`   | LDAP user suffix                               | `nil`        |
+| `config.auth.ldap.ldap_bind_user`     | LDAP bind user                                 | `nil`        |
+| `config.auth.ldap.ldap_bind_password` | LDAP bind password                             | `nil`        |
+| `config.auth.ldap.ldap_base_dn`       | LDAP base dn                                   | `nil`        |
+| `config.auth.ldap.ldap_search_filter` | LDAP search filter                             | `nil`        |
+| `config.auth.ldap.import_user`        | User import from LDAP on login                 | `nil`        |
+| `config.auth.ldap.attrs.username`     | Variable name for username in LDAP             | `nil`        |
+| `config.auth.ldap.attrs.full_name`    | Variable name for user full name in LDAP       | `nil`        |
+| `config.auth.ldap.attrs.email`        | Variable name for user email in LDAP           | `nil`        |
+| `config.auth.ldap.attrs.call`         | Variable name for user phone contact in LDAP   | `nil`        |
+| `config.auth.ldap.attrs.sms`          | Variable name for user sms contact in LDAP     | `nil`        |
+| `config.auth.ldap.attrs.slack`        | Variable name for user slack in LDAP           | `nil`        |
+| `config.timezone`                     | Default timezone                               | `US/Pacific` |
+
+### Ingress parameters
+
+| Parameter             | Description                           | Default        |
+|-----------------------|---------------------------------------|----------------|
+| `ingress.enabled`     | Enable ingress controller resource    | `false`        |
+| `ingress.class`       | Class used in ingress controller      | `nginx`        |
+| `ingress.certManager` | Add annotations for cert-manager      | `true`         |
+| `ingress.hostname`    | Default host for the ingress resource | `oncall.local` |
+| `ingress.tls`         | TLS status in ingress controller      | `true`         |
+
+### Database parameters
+
+| Parameter                        | Description                          | Default |
+|----------------------------------|--------------------------------------|---------|
+| `dbInitialized`                  | Is database initialized              | `false` |
+| `mysql.auth.rootPassword`        | Password for the root user           | `1234`  |
+| `mysql.primary.persistence.size` | MySQL primary persistent volume size | `1Gi`   |

--- a/ops/charts/oncall/config/config.yaml
+++ b/ops/charts/oncall/config/config.yaml
@@ -3,8 +3,8 @@
 #######################
 server:
   host: 0.0.0.0
-  port: {{ .Values.oncallService.internalPort }}
-oncall_host: http://localhost:{{ .Values.oncallService.internalPort }}
+  port: {{ .Values.port.internal }}
+oncall_host: http://localhost:{{ .Values.port.internal }}
 metrics: dummy
 db:
   conn:
@@ -44,66 +44,12 @@ debug: True
 # class, with two required methods: __init__(self, config) and
 # authenticate(self, username, password)
 auth:
-  debug: {{ .Values.oncallService.auth.debug | toString | title }}
-  {{- if .Values.oncallService.auth.modules.debug }}
-  module: 'oncall.auth.modules.debug'  # Auth module where Authenticator is implemented
-  {{- end }}
+  debug: {{ .Values.config.auth.debug }}
+  module: 'oncall.auth.modules.{{ .Values.config.auth.module }}'
 
 # Example configuration for LDAP-based auth
-  {{- if .Values.oncallService.auth.modules.ldap_example }}
-  module: 'oncall.auth.modules.ldap_example'
-  {{- end }}
-  {{- if .Values.oncallService.auth.modules.ldap_import }}
-  module: 'oncall.auth.modules.ldap_import' # for automatically import user at first connexion
-  {{- end }}
-  {{- if .Values.oncallService.auth.ldap_url }}
-  ldap_url: {{ .Values.oncallService.auth.ldap_url | squote }}
-  {{- end }}
-  {{- if .Values.oncallService.auth.ldap_user_suffix }}
-  ldap_user_suffix: {{ .Values.oncallService.auth.ldap_user_suffix | squote }}
-  {{- end }}
-  {{- if .Values.oncallService.auth.ldap_cert_path }}
-  ldap_cert_path: {{ .Values.oncallService.auth.ldap_cert_path | squote }}
-  {{- end }}
-  {{- if .Values.oncallService.auth.ldap_bind_user }}
-  ldap_bind_user: {{ .Values.oncallService.auth.ldap_bind_user | squote }}
-  {{- end }}
-  {{- if .Values.oncallService.auth.ldap_bind_password }}
-  ldap_bind_password: {{ .Values.oncallService.auth.ldap_bind_password | squote }}
-  {{- end }}
-  {{- if .Values.oncallService.auth.ldap_base_dn }}
-  ldap_base_dn: {{ .Values.oncallService.auth.ldap_base_dn | squote }}
-  {{- end }}
-  {{- if .Values.oncallService.auth.ldap_search_filter }}
-  ldap_search_filter: {{ .Values.oncallService.auth.ldap_search_filter | squote }}
-  {{- end }}
-# options used by the ldap_import module.
-  {{- if kindIs "bool" .Values.oncallService.auth.import_user }}
-  import_user: {{ .Values.oncallService.auth.import_user | toString | title }}
-  {{- end }}
-  {{- if .Values.oncallService.auth.attrs }}
-  attrs:
-    {{- if .Values.oncallService.auth.attrs.username }}
-    username: {{ .Values.oncallService.auth.attrs.username | squote }}
-    {{- end }}
-    {{- if .Values.oncallService.auth.attrs.full_name }}
-    full_name: {{ .Values.oncallService.auth.attrs.full_name | squote }}
-    {{- end }}
-    {{- if .Values.oncallService.auth.attrs.email }}
-    email: {{ .Values.oncallService.auth.attrs.email | squote }}
-    {{- end }}
-    {{- if .Values.oncallService.auth.attrs.call }}
-    call: {{ .Values.oncallService.auth.attrs.call | squote }}
-    {{- end }}
-    {{- if .Values.oncallService.auth.attrs.sms }}
-    sms: {{ .Values.oncallService.auth.attrs.sms | squote }}
-    {{- end }}
-    {{- if .Values.oncallService.auth.attrs.slack }}
-    slack: {{ .Values.oncallService.auth.attrs.slack | squote }}
-    {{- end }}
-    {{- if .Values.oncallService.auth.attrs.name }}
-    name: {{ .Values.oncallService.auth.attrs.name | squote }}
-    {{- end }}
+  {{- if .Values.config.auth.ldap }}
+  {{- toYaml .Values.config.auth.ldap | nindent 2 }}
   {{- end }}
 
 ############################
@@ -133,7 +79,7 @@ notifications:
 reminder:
   activated: True
   polling_interval: 360  # In seconds, the reminder will poll DB for events every $n seconds
-  default_timezone: {{ .Values.oncallService.timezone | squote }}  # Dates/times in the reminders are formatted in this timezone
+  default_timezone: {{ .Values.config.timezone | squote }}  # Dates/times in the reminders are formatted in this timezone
 
 # User validator checks that people scheduled for on-call events have defined phone numbers
 user_validator:
@@ -165,8 +111,8 @@ messengers:
 ### Oncall frontend settings
 ############################
 supported_timezones:
-  {{- if .Values.oncallService.timezone }}
-  - {{ .Values.oncallService.timezone | squote }}
+  {{- if .Values.config.timezone }}
+  - {{ .Values.config.timezone | squote }}
   {{- end }}
   - 'US/Eastern'
   - 'US/Central'
@@ -192,7 +138,7 @@ header_color: '#3a3a3a'
 # The base url for the public oncall calendar. This url has to open to the public internet for most web calendar subscriptions to work.
 # The public calendar url will be formatted as follows: "{public_calendar_base_url}/{ical_key}".
 # Replace localhost with the hostname of the oncall or iris-relay instance.
-public_calendar_base_url: 'http://localhost:{{ .Values.oncallService.internalPort }}/api/v0/ical'
+public_calendar_base_url: 'http://localhost:{{ .Values.port.internal }}/api/v0/ical'
 # Additional message you want to put here, could be a link to the FAQ
 public_calendar_additional_message: 'Link to FAQ'
 

--- a/ops/charts/oncall/requirements.lock
+++ b/ops/charts/oncall/requirements.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: mysql
-  repository: https://charts.bitnami.com/bitnami
-  version: 8.0.0
-digest: sha256:290300d7be7bcc2a1d5d9da973d66c21167a56e924b7140d376a06f88f74fd8a
-generated: "2020-12-03T11:55:11.445613061+01:00"

--- a/ops/charts/oncall/requirements.yaml
+++ b/ops/charts/oncall/requirements.yaml
@@ -1,4 +1,0 @@
-dependencies:
-  - name: mysql
-    version: 8.0.0
-    repository: https://charts.bitnami.com/bitnami

--- a/ops/charts/oncall/templates/NOTES.txt
+++ b/ops/charts/oncall/templates/NOTES.txt
@@ -1,17 +1,13 @@
 ## For internal access
 
-The Oncall service can be accessed via port {{ .Values.oncallService.externalPort }} on the following DNS names from within your cluster:
+The Oncall service can be accessed via port {{ .Values.port.external }} on the following DNS names from within your cluster:
 
     `oncall` or `oncall.{{ .Release.Namespace }}.svc.cluster.local`
 
 
 ## For external access
 
-Oncall service is configured to use NodePort type, you can use the following
+Oncall service is configured to use ClusterIP type, you can use the following
 command to get the external port for the service:
 
     kubectl describe services oncall
-
-For external IP, use:
-
-    kubectl cluster-info

--- a/ops/charts/oncall/templates/config-map.yaml
+++ b/ops/charts/oncall/templates/config-map.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: oncall-config
+  name: {{ include "fullname" . }}
 data:
   config.yaml: |-
-{{ tpl (.Files.Get "config/config.yaml") . | nindent 4 }}
+    {{ tpl (.Files.Get "config/config.yaml") . | nindent 4 }}

--- a/ops/charts/oncall/templates/deployment.yaml
+++ b/ops/charts/oncall/templates/deployment.yaml
@@ -21,26 +21,31 @@ spec:
     spec:
       containers:
         - name: oncall
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
           ports:
-            - containerPort: {{ .Values.oncallService.internalPort }}
+            - containerPort: {{ .Values.port.internal }}
           env:
-            {{- if not .Values.oncallService.dbInitialized }}
+            {{- if not .Values.dbInitialized }}
             - name: DOCKER_DB_BOOTSTRAP
               value: '1'
             {{- end }}
           volumeMounts:
             - name: oncall-volume
-              mountPath: /home/oncall/config
+              mountPath: /home/oncall/config/config.yaml
+              subPath: config.yaml
               readOnly: true
           readinessProbe:
             httpGet:
               path: /healthcheck
-              port: 8080
-            initialDelaySeconds: 5
+              port: {{ .Values.port.internal }}
+            initialDelaySeconds: 60
             periodSeconds: 10
+      initContainers:
+        - name: init-oncall
+          image: busybox:latest
+          command: ['sh', '-c', "until nslookup {{ include "mysql.fullname" . }}; do echo waiting for mysql; sleep 2; done; sleep 20"]
       volumes:
         - name: oncall-volume
           configMap:
-            name: oncall-config
+            name: {{ include "fullname" . }}

--- a/ops/charts/oncall/templates/ingress.yaml
+++ b/ops/charts/oncall/templates/ingress.yaml
@@ -16,7 +16,7 @@ spec:
         paths:
         - backend:
             serviceName: {{ template "name" . }}
-            servicePort: {{ .Values.oncallService.externalPort }}
+            servicePort: {{ .Values.port.external }}
           path: /
     {{- end }}
   {{- if .Values.ingress.tls }}

--- a/ops/charts/oncall/templates/service.yaml
+++ b/ops/charts/oncall/templates/service.yaml
@@ -10,9 +10,9 @@ metadata:
 spec:
   ports:
     - name: {{ template "name" . }}
-      port: {{ .Values.oncallService.externalPort }}
-      targetPort: {{ .Values.oncallService.internalPort }}
+      port: {{ .Values.port.external }}
+      targetPort: {{ .Values.port.internal }}
       protocol: TCP
   selector:
     app: {{ template "fullname" . }}
-  type: NodePort
+  type: ClusterIP

--- a/ops/charts/oncall/values.yaml
+++ b/ops/charts/oncall/values.yaml
@@ -4,24 +4,40 @@ image:
 pullPolicy: "alwaysPull"
 replicaCount: 1
 
-oncallService:
-  externalPort: 80
-  internalPort: 8080
-  dbInitialized: False
+port:
+  external: 80
+  internal: 8080
+
+dbInitialized: false
+
+config:
   auth:
-    debug: True
-    modules:
-      debug: True
-      ldap_example: False
-      ldap_import: False
+    debug: true
+    module: debug
+    # ldap:
+    #   ldap_url: 'ldaps://example.com'
+    #   ldap_user_suffix: '@example.biz'
+    #   ldap_cert_path: '/etc/ldap_cert.pem'
+    #   ldap_bind_user: 'cn=binduser,ou=services,dc=company,dc=org'
+    #   ldap_bind_password: 'abc123'
+    #   ldap_base_dn: 'ou=accounts,dc=company,dc=org'
+    #   ldap_search_filter: '(uid=%s)'
+    #   import_user: True
+    #   attrs:
+    #     username: 'uid'
+    #     full_name: 'displayName'
+    #     email: 'mail'
+    #     mobile: 'mobile'
+    #     sms: 'phone'
+    #     slack: 'uid'
   timezone: 'US/Pacific'
 
 ingress:
-  enabled: False
+  enabled: false
   class: nginx
-  certManager: True
-  hostname: "test.com"
-  tls: True
+  certManager: true
+  hostname: "oncall.local"
+  tls: true
 
 mysql:
   auth:


### PR DESCRIPTION
### Description
Helm3 chart:
- code refactoring in file `values.yaml`
- updated `README.md` with values examples
- code refactoring in file `config.yaml`
- updated `readinessProbe` with new `initialDelaySeconds`
- added `initContainers` to deployment 


### For testing:
Latest image available at official Docker repository for the oncall is 3 years old (https://quay.io/repository/iris/oncall?tab=tags), so it won't work with up to date mysql used in this code: 
```
ERROR 2026 (HY000): SSL connection error: unknown error number
```
As a permanent fix updated image should be pushed to quay.io (or Docker Hub; it took me 5 minutes to create account and set up automatic build), as a quick fix for anyone interested in using chart I suggest:
- build oncall image from source and configuring image registry
- or use my image from Docker Hub, to do this change line 1 in file `ops/charts/oncall/values.yaml` to:
```
imageRegistry: "lukdz"
```