### PR TITLE
Switch to updated docker repository

### DIFF
--- a/ops/charts/oncall/values.yaml
+++ b/ops/charts/oncall/values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: "quay.io/repository/diegocepedaw/oncall"
+  repository: "quay.io/diegocepedaw"
   tag: "latest"
 pullPolicy: "alwaysPull"
 replicaCount: 1

--- a/ops/charts/oncall/values.yaml
+++ b/ops/charts/oncall/values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: "quay.io/iris"
+  repository: "quay.io/repository/diegocepedaw/oncall"
   tag: "latest"
 pullPolicy: "alwaysPull"
 replicaCount: 1

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,8 @@ setuptools.setup(
         'irisclient',
         'slackclient==1.3.1',
         'icalendar',
-        'pymsteams'
+        'pymsteams',
+        'idna==2.10'
     ],
     extras_require={
         'ldap': ['python-ldap'],


### PR DESCRIPTION
Old quay.io/iris is defunct, update to the new repository. This new repo should automatically build a new version with every new commit that is pushed to the linkedin/oncall repo.