### PR TITLE
Fix no-skip-match preview bug

### DIFF
--- a/src/oncall/scheduler/default.py
+++ b/src/oncall/scheduler/default.py
@@ -135,7 +135,7 @@ class Scheduler(object):
             logger.debug('Found new guy')
         return {row['id'] for row in cursor}
 
-    def create_events(self, team_id, schedule_id, user_id, events, role_id, cursor, skip_match=True, table_name='event'):
+    def create_events(self, team_id, schedule_id, user_id, events, role_id, cursor,  table_name='event', skip_match=True):
         if len(events) == 0:
             return
         # Skip creating this epoch of events if matching events exist
@@ -406,5 +406,5 @@ class Scheduler(object):
             user_id = self.find_next_user_id(schedule, epoch, cursor, table_name)
             if not user_id:
                 continue
-            self.create_events(team_id, schedule['id'], user_id, epoch, role_id, cursor, table_name=table_name)
+            self.create_events(team_id, schedule['id'], user_id, epoch, role_id, cursor, table_name)
         connection.commit()

--- a/src/oncall/scheduler/default.py
+++ b/src/oncall/scheduler/default.py
@@ -135,7 +135,7 @@ class Scheduler(object):
             logger.debug('Found new guy')
         return {row['id'] for row in cursor}
 
-    def create_events(self, team_id, schedule_id, user_id, events, role_id, cursor,  table_name='event', skip_match=True):
+    def create_events(self, team_id, schedule_id, user_id, events, role_id, cursor, table_name='event', skip_match=True):
         if len(events) == 0:
             return
         # Skip creating this epoch of events if matching events exist

--- a/src/oncall/scheduler/no-skip-matching.py
+++ b/src/oncall/scheduler/no-skip-matching.py
@@ -2,5 +2,5 @@ from . import default
 
 
 class Scheduler(default.Scheduler):
-    def create_events(self, team_id, schedule_id, user_id, events, role_id, cursor, skip_match=True, table_name='event'):
-        super(Scheduler, self).create_events(team_id, schedule_id, user_id, events, role_id, cursor, skip_match=False, table_name='event')
+    def create_events(self, team_id, schedule_id, user_id, events, role_id, cursor, table_name='event', skip_match=True):
+        super(Scheduler, self).create_events(team_id, schedule_id, user_id, events, role_id, cursor, table_name, skip_match=False)

--- a/src/oncall/scheduler/round-robin.py
+++ b/src/oncall/scheduler/round-robin.py
@@ -50,7 +50,7 @@ class Scheduler(default.Scheduler):
         last_idx = roster.index(last_user)
         return roster[(last_idx + 1) % len(roster)]
 
-    def create_events(self, team_id, schedule_id, user_id, events, role_id, cursor, skip_match=True, table_name='event'):
+    def create_events(self, team_id, schedule_id, user_id, events, role_id, cursor, table_name='event', skip_match=True):
         if len(events) == 1:
             [event] = events
             event_args = (team_id, schedule_id, event['start'], event['end'], user_id, role_id)


### PR DESCRIPTION
If a schedule is using the default (duplicates allowed) scheduler using the preview schedule functionality will add events to the calendar instead of previewing them, this PR addresses that issue.