### PR TITLE
fixed handling of teams with trailing/leading spaces in team name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     docker:
       - image: circleci/python:3.7-stretch-browsers
-      - image: mysql/mysql-server:5.7
+      - image: mysql/mysql-server:5.7.33
         environment:
           - MYSQL_ROOT_PASSWORD=1234
           - MYSQL_ROOT_HOST=%

--- a/e2e/test_teams.py
+++ b/e2e/test_teams.py
@@ -19,6 +19,16 @@ def test_api_v0_create_team(team):
     # Add to team fixture to ensure cleanup
     team.mark_for_cleaning(team_name)
 
+@prefix('test_v0_create_team_with_space')
+def test_api_v0_create_team_with_space(team):
+    team_name = " v0_create_team "
+    requests.delete(api_v0('teams/'+team_name))
+    re = requests.post(api_v0('teams'), json={"name": team_name, 'scheduling_timezone': 'utc'})
+    teams = requests.get(api_v0('teams')).json()
+    assert "v0_create_team" in teams
+    assert " v0_create_team " not in teams
+    # Add to team fixture to ensure cleanup
+    team.mark_for_cleaning(team_name)
 
 @prefix('test_v0_invalid_team')
 def test_api_v0_create_invalid_team(team):

--- a/e2e/test_teams.py
+++ b/e2e/test_teams.py
@@ -21,12 +21,13 @@ def test_api_v0_create_team(team):
 
 @prefix('test_v0_create_team_with_space')
 def test_api_v0_create_team_with_space(team):
-    team_name = " v0_create_team "
+    team_name = "v0_create_team_team"
+    team_name_with_space = " v0_create_team_team "
     requests.delete(api_v0('teams/'+team_name))
-    re = requests.post(api_v0('teams'), json={"name": team_name, 'scheduling_timezone': 'utc'})
+    re = requests.post(api_v0('teams'), json={"name": team_name_with_space, 'scheduling_timezone': 'utc'})
     teams = requests.get(api_v0('teams')).json()
-    assert "v0_create_team" in teams
-    assert " v0_create_team " not in teams
+    assert team_name in teams
+    assert team_name_with_space not in teams
     # Add to team fixture to ensure cleanup
     team.mark_for_cleaning(team_name)
 

--- a/src/oncall/api/v0/teams.py
+++ b/src/oncall/api/v0/teams.py
@@ -151,7 +151,7 @@ def on_post(req, resp):
         raise HTTPBadRequest('', 'name attribute missing from request')
     if not data.get('scheduling_timezone'):
         raise HTTPBadRequest('', 'scheduling_timezone attribute missing from request')
-    team_name = unquote(data['name'])
+    team_name = unquote(data['name']).strip()
     invalid_char = invalid_char_reg.search(team_name)
     if invalid_char:
         raise HTTPBadRequest('invalid team name',

--- a/src/oncall/auth/__init__.py
+++ b/src/oncall/auth/__init__.py
@@ -51,12 +51,13 @@ def check_user_auth(user, req):
         JOIN `team_user` ON `team_admin`.`team_id` = `team_user`.`team_id`
         JOIN `user` ON `user`.`id` = `team_user`.`user_id`
         JOIN `user` AS `admin` ON `admin`.`id` = `team_admin`.`user_id`
-        WHERE `admin`.`name` = %s'''
-    cursor.execute(get_allowed_query, challenger)
-    allowed = (user,) in cursor
+        WHERE `admin`.`name` = %s
+        AND `user`.`name` = %s'''
+    cursor.execute(get_allowed_query, (challenger, user))
+    user_in_query = cursor.rowcount
     cursor.close()
     connection.close()
-    if allowed or is_god(challenger):
+    if user_in_query != 0 or is_god(challenger):
         return
     raise HTTPForbidden('Unauthorized', 'Action not allowed for "%s"' % challenger)
 
@@ -74,12 +75,13 @@ def check_team_auth(team, req):
                            FROM `team_admin`
                            JOIN `team` ON `team_admin`.`team_id` = `team`.`id`
                            JOIN `user` ON `team_admin`.`user_id` = `user`.`id`
-                           WHERE `user`.`name` = %s'''
-    cursor.execute(get_allowed_query, challenger)
-    allowed = (team,) in cursor
+                           WHERE `user`.`name` = %s
+                           AND `team`.`name` = %s'''
+    cursor.execute(get_allowed_query, (challenger, team))
+    team_in_query = cursor.rowcount
     cursor.close()
     connection.close()
-    if allowed or is_god(challenger):
+    if team_in_query != 0 or is_god(challenger):
         return
     raise HTTPForbidden(
         'Unauthorized',


### PR DESCRIPTION
This passes all of the tests built into the repo and includes one new one to test this specific edge case.

This commit prevents new teams from being created with a leading/trailing space (spaces are automatically removed). It also changes the way some auth comparisons are done so that SQL is used instead of Python for comparisons, which should fix any auth issues for existing teams with a leading or trailing space.