### PR TITLE
support UTF-8 in YAMLs with Python3

### DIFF
--- a/src/oncall/bin/notifier.py
+++ b/src/oncall/bin/notifier.py
@@ -34,7 +34,7 @@ default_timezone = None
 
 
 def load_config_file(config_path):
-    with open(config_path) as h:
+    with open(config_path, 'r', encoding='utf-8') as h:
         config = yaml.safe_load(h)
 
     if 'init_config_hook' in config:

--- a/src/oncall/user_sync/ldap_sync.py
+++ b/src/oncall/user_sync/ldap_sync.py
@@ -438,6 +438,6 @@ def main(config):
 
 if __name__ == '__main__':
     config_path = sys.argv[1]
-    with open(config_path, 'r') as config_file:
+    with open(config_path, 'r', encoding='utf-8') as config_file:
         config = yaml.safe_load(config_file)
     main(config)


### PR DESCRIPTION
* use binary mode for parsing YAML
* this is needed in Python v3 for support of the UTF8
* otherwise it will fail when using ascii codec
  `UnicodeDecodeError: 'ascii' codec can't decode byte`
* there is C2A9 character in the example config.yaml :)
* tested with Python 3.6 and PyYAML 6.0