### PR TITLE
User allow/prevent calendar modification by non admin user

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -194,6 +194,9 @@ slack_instance: foobar
 # APIs without authentication
 require_auth: False
 
+# Setting to determine whether the autheticated user can modify calendar entries.
+auth_user_cal_mod: False
+
 ###########################
 ### Oncall bonus management
 ###########################

--- a/src/oncall/constants.py
+++ b/src/oncall/constants.py
@@ -39,6 +39,7 @@ GRACE_PERIOD = None
 
 SUPPORTED_TIMEZONES = None
 
+AUTH_USER_CAL_MOD = None
 
 def init(config):
     global DEFAULT_ROLES
@@ -46,8 +47,10 @@ def init(config):
     global DEFAULT_TIMES
     global SUPPORTED_TIMEZONES
     global GRACE_PERIOD
+    global AUTH_USER_CAL_MOD
     DEFAULT_ROLES = config['notifications']['default_roles']
     DEFAULT_MODES = config['notifications']['default_modes']
     DEFAULT_TIMES = config['notifications']['default_times']
     SUPPORTED_TIMEZONES = config['supported_timezones']
     GRACE_PERIOD = config.get('grace_period', 86400)
+    AUTH_USER_CAL_MOD = config.get('auth_user_cal_mod')


### PR DESCRIPTION
Add a configuration in config.yaml to authorize or not user that are not admin of a team to modify a team calendar.

The objective of that mod is to prevent 'simple' user to modify team calendar.
