### PR TITLE
Pin `markupsafe` to `2.0.1`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
         'asn1crypto==1.0.0',
         'gevent==1.4.0',
         'ujson',
-        'markupsafe',
+        'markupsafe==2.0.1',
         'sqlalchemy',
         'PyYAML',
         'PyMYSQL',


### PR DESCRIPTION
# Summary

Pin `markupsafe` to `2.0.1`

Fixes #369 

# Tested via:

### Ensure all old unused `oncall` docker images & build cache are purged from system
```
docker image prune --all --force
docker builder prune --all --force
```

### Rebuild `oncall` image, pull new images & deploy
```
docker-compose up -d
```

### Confirm `oncall` service is running via accessing web UI
![Screen Shot 2022-05-08 at 22 39 38](https://user-images.githubusercontent.com/6374067/167347225-ae98e5b2-0f7c-4f89-a44d-0b169ef1bf1d.png)
