### PR TITLE
Don't require auth for fetching public ical

### DIFF
--- a/src/oncall/api/v0/public_ical.py
+++ b/src/oncall/api/v0/public_ical.py
@@ -10,6 +10,8 @@ from .ical_key import get_name_and_type_from_key
 from .user_ical import get_user_events
 from .team_ical import get_team_events
 
+allow_no_auth = True
+
 
 def on_get(req, resp, key):
     """Get ical file for a user or team's oncall calendar with no contact


### PR DESCRIPTION
The public ical endpoint is designed to be fetched by calendar applications with no authentication, so exclude it from auth enforcement.