### PR TITLE
Add new query param "excludedTeams" to iCal API endpoint

### DIFF
--- a/e2e/test_ical.py
+++ b/e2e/test_ical.py
@@ -36,6 +36,40 @@ def test_user_ical(event, team, user, role):
             assert start == calendar.timegm(component.get('dtstart').dt.timetuple())
             assert end == calendar.timegm(component.get('dtend').dt.timetuple())
 
+@prefix('test_user_ical_exclude_team')
+def test_user_ical_exclude_team(event, team, user, role):
+    team_name = team.create()
+    team_name_2 = team.create()
+    user_name = user.create()
+    role_name = role.create()
+    user.add_to_team(user_name, team_name)
+    user.add_to_team(user_name, team_name_2)
+
+    start = int(time.time()) + 100
+    end = start + 1000
+
+    ev1 = event.create({'start': start,
+                        'end': end,
+                        'user': user_name,
+                        'team': team_name,
+                        'role': role_name})
+    ev2 = event.create({'start': start + 100,
+                        'end': end + 100,
+                        'user': user_name,
+                        'team': team_name_2,
+                        'role': role_name})
+
+    re = requests.get(api_v0('users/%s/ical?excludedTeams=%s' % (user_name, team_name_2)))
+    cal = re.content
+    # Parse icalendar, make sure event info is correct (excluded team's event should not be present)
+    ical = icalendar.Calendar.from_ical(re.content)
+    for component in ical.walk():
+        if component.name == 'VEVENT':
+            assert user_name in component.get('description')
+            assert team_name_2 not in component.get('summary')
+            assert start == calendar.timegm(component.get('dtstart').dt.timetuple())
+            assert end == calendar.timegm(component.get('dtend').dt.timetuple())
+
 
 @prefix('test_team_ical')
 def test_team_ical(event, team, user, role):

--- a/e2e/test_ical.py
+++ b/e2e/test_ical.py
@@ -63,12 +63,16 @@ def test_user_ical_exclude_team(event, team, user, role):
     cal = re.content
     # Parse icalendar, make sure event info is correct (excluded team's event should not be present)
     ical = icalendar.Calendar.from_ical(re.content)
+    num_events = 0
     for component in ical.walk():
         if component.name == 'VEVENT':
+            num_events += 1
             assert user_name in component.get('description')
             assert team_name_2 not in component.get('summary')
             assert start == calendar.timegm(component.get('dtstart').dt.timetuple())
             assert end == calendar.timegm(component.get('dtend').dt.timetuple())
+    # Make sure that there is only 1 event parsed (excluded team event not included)
+    assert num_events == 1
 
 
 @prefix('test_team_ical')

--- a/src/oncall/api/v0/public_ical.py
+++ b/src/oncall/api/v0/public_ical.py
@@ -17,6 +17,7 @@ def on_get(req, resp, key):
 
     """
     roles = req.get_param_as_list('roles')
+    excluded_teams = req.get_param_as_list('excludedTeams')
 
     name_and_type = get_name_and_type_from_key(key)
     if name_and_type is None:
@@ -26,7 +27,7 @@ def on_get(req, resp, key):
     start = int(time.time())
     events = []
     if type == 'user':
-        events = get_user_events(name, start, roles=roles)
+        events = get_user_events(name, start, roles=roles, excluded_teams=excluded_teams)
     elif type == 'team':
         events = get_team_events(name, start, roles=roles, include_subscribed=True)
 

--- a/src/oncall/api/v0/teams.py
+++ b/src/oncall/api/v0/teams.py
@@ -26,6 +26,16 @@ constraints = {
     'email__endswith': '`team`.`email` LIKE CONCAT("%%", %s)',
 }
 
+def get_team_ids(cursor, team_names):
+    if not team_names:
+        return []
+
+    team_query = 'SELECT DISTINCT `id` FROM `team` WHERE `name` IN ({0})'.format(
+        ','.join(['%s'] * len(team_names)))
+    # we need prepared statements here because team_names come from user input
+    cursor.execute(team_query, team_names)
+    return [row['id'] for row in cursor]
+
 
 def on_get(req, resp):
     '''

--- a/src/oncall/api/v0/teams.py
+++ b/src/oncall/api/v0/teams.py
@@ -26,6 +26,7 @@ constraints = {
     'email__endswith': '`team`.`email` LIKE CONCAT("%%", %s)',
 }
 
+
 def get_team_ids(cursor, team_names):
     if not team_names:
         return []


### PR DESCRIPTION
This adds a new query parameter "excludedTeams" to the iCal API endpoint that allows users to filter out events on a team-by-team basis. This param works the same as the existing "roles" parameter.

Added a unit test and verified locally that it filters out events by team.