### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/create-release-and-publish.yml
+++ b/.github/workflows/create-release-and-publish.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@master
       - name: Get version
         id: get_version
-        run: echo "::set-output name=version::$(grep -Po '\d*\.\d*\.\d*' src/oncall/__init__.py)"
+        run: echo "version=$(grep -Po '\d*\.\d*\.\d*' src/oncall/__init__.py)" >> $GITHUB_OUTPUT
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


