### PR TITLE
Added user_manager table for tracking management relationships

### DIFF
--- a/db/dummy_data.sql
+++ b/db/dummy_data.sql
@@ -122,6 +122,14 @@ INSERT INTO `user_contact` VALUES
 UNLOCK TABLES;
 
 
+LOCK TABLES `user_manager` WRITE;
+/*!40000 ALTER TABLE `user_manager` DISABLE KEYS */;
+INSERT INTO `user_manager` VALUES
+    (3, 2),
+    (2, 1);
+/*!40000 ALTER TABLE `user_manager` ENABLE KEYS */;
+UNLOCK TABLES;
+
 LOCK TABLES `event` WRITE;
 /*!40000 ALTER TABLE `event` DISABLE KEYS */;
 INSERT INTO `event` (`id`, `team_id`, `role_id`, `schedule_id`, `user_id`, `start`, `end`) VALUES

--- a/db/schema.v0.sql
+++ b/db/schema.v0.sql
@@ -333,6 +333,19 @@ CREATE TABLE IF NOT EXISTS `user_contact` (
 );
 
 -- -----------------------------------------------------
+-- Table `user_manager`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `user_manager` (
+  `report_id` BIGINT(20) UNSIGNED NOT NULL,
+  `manager_id` BIGINT(20) UNSIGNED NOT NULL,
+  PRIMARY KEY (`report_id`),
+  CONSTRAINT `user_manager_report_id_fk` FOREIGN KEY (`report_id`) REFERENCES `user` (`id`)
+  ON DELETE CASCADE,
+  CONSTRAINT `user_manager_manager_id_fk` FOREIGN KEY (`manager_id`) REFERENCES `user` (`id`)
+  ON DELETE CASCADE
+);
+
+-- -----------------------------------------------------
 -- Table `audit`
 -- -----------------------------------------------------
 CREATE TABLE IF NOT EXISTS `audit` (


### PR DESCRIPTION
This adds a new table `user_manager` that is a one-to-many relationship between a user and another user, who can manage multiple people. This can be used for a future API endpoint that will be able to fetch a user's manager to the requested depth in order to help escalate up the management chain.

Tested by creating a local DB and building the schema and importing dummy data from scratch.